### PR TITLE
Fix array-of-array handling when parsing ABI types

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,8 +15,11 @@ Fixed
 ^^^^^
 
 - Multiple fixes for typing of methods. (PR_1_)
+- Fixed the handling of array-of-array ABI types. (PR_2_)
+
 
 .. _PR_1: https://github.com/fjarri/pons/pull/1
+.. _PR_2: https://github.com/fjarri/pons/pull/2
 
 
 0.2.0 (19-03-2022)

--- a/pons/contract_abi.py
+++ b/pons/contract_abi.py
@@ -33,7 +33,7 @@ class Parameter:
 
 def dispatch_type(abi_entry):
     type_str = abi_entry['type']
-    match = re.match(r"(\w+)(\[(\d+)?\])?", type_str)
+    match = re.match(r"^(.*?)(\[(\d+)?\])?$", type_str)
     if not match:
         raise Exception(f"Incorrect type format: {type_str}")
 


### PR DESCRIPTION
Previously, for types like `uint256[2][]`, the outer array (`[]`) was just ignored.