### PR TITLE
Use `anyio` in the main package instead of `trio`

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,7 +5,13 @@ Changelog
 Unreleased
 ~~~~~~~~~~
 
-Under construction.
+Added
+^^^^^
+
+- ``anyio`` support instead of just ``trio``. (PR_27_)
+
+
+.. _PR_27: https://github.com/fjarri/pons/pull/27
 
 
 0.4.0 (23-04-2022)

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -3,6 +3,13 @@
 Tutorial
 ========
 
+
+Async support
+-------------
+
+While the examples and tests use ``trio``, ``pons`` is ``anyio``-based and supports all the corresponding backends.
+
+
 Sessions
 --------
 

--- a/pons/_client.py
+++ b/pons/_client.py
@@ -2,7 +2,7 @@ from contextlib import asynccontextmanager
 from functools import wraps
 from typing import Union, Any, Optional, AsyncIterator
 
-import trio
+import anyio
 
 from ._contract import (
     DeployedContract,
@@ -207,7 +207,7 @@ class ClientSession:
             receipt = await self.eth_get_transaction_receipt(tx_hash)
             if receipt:
                 return receipt
-            await trio.sleep(poll_latency)
+            await anyio.sleep(poll_latency)
 
     @rpc_call("eth_call")
     async def eth_call(self, call: BoundReadCall, block: Union[int, Block] = Block.LATEST) -> Any:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,11 @@ authors = [
     {name = "Bogdan Opanchuk", email = "bogdan@opanchuk.net"},
 ]
 dependencies = [
-    "trio>=0.19.0",
     "httpx>=0.22",
     "eth-account>=0.5",
     "eth-utils>=1.10",
     "eth-abi>=2",
+    "anyio>=3",
     "setuptools", # required by eth-utils, but it just assumes that it's already installed
 ]
 requires-python = ">=3.8"
@@ -22,6 +22,7 @@ homepage = "https://github.com/fjarri/pons"
 [project.optional-dependencies]
 dev = [
     "pytest>=6",
+    "trio>=0.19.0",
     "pytest-trio",
     "pytest-cov",
     "py-solc-x>=1",


### PR DESCRIPTION
Tests still have `trio` - it has more developed testing utilities, and the ASGI server we use (`hypercorn`) does not yet support `anyio` (see https://gitlab.com/pgjones/hypercorn/-/issues/183)

Fixes #13