### PR TITLE
Handle decoding errors from `eth_abi`

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -26,6 +26,8 @@ Providers
 Errors
 ------
 
+.. autoclass:: pons.ABIDecodingError
+
 .. autoclass:: pons.RemoteError
 
 .. autoclass:: pons.Unreachable

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,9 +9,11 @@ Added
 ^^^^^
 
 - ``anyio`` support instead of just ``trio``. (PR_27_)
+- Raise ``ABIDecodingError`` on mismatch between the declared contract ABI and the bytestring returned from ``ethCall``. (PR_29_)
 
 
 .. _PR_27: https://github.com/fjarri/pons/pull/27
+.. _PR_29: https://github.com/fjarri/pons/pull/29
 
 
 0.4.0 (23-04-2022)

--- a/pons/__init__.py
+++ b/pons/__init__.py
@@ -1,6 +1,7 @@
 from . import abi
 from ._client import Client, RemoteError
 from ._contract_abi import (
+    ABIDecodingError,
     ContractABI,
     Constructor,
     ReadMethod,

--- a/pons/_client.py
+++ b/pons/_client.py
@@ -29,7 +29,7 @@ from ._entities import (
     encode_block,
     decode_quantity,
     decode_data,
-    DecodingError,
+    RPCDecodingError,
 )
 
 
@@ -107,7 +107,7 @@ def rpc_call(method_name):
         async def _wrapped(*args, **kwargs):
             try:
                 result = await func(*args, **kwargs)
-            except (DecodingError, UnexpectedResponse) as exc:
+            except (RPCDecodingError, UnexpectedResponse) as exc:
                 raise BadResponseFormat(f"{method_name}: {exc}") from exc
             except RPCError as exc:
                 if exc.code == RPCErrorCode.EXECUTION_ERROR:
@@ -140,7 +140,7 @@ class ClientSession:
         if self._net_version is None:
             result = await self._provider_session.rpc("net_version")
             if not isinstance(result, str):
-                raise DecodingError("expected a string result")
+                raise RPCDecodingError("expected a string result")
             self._net_version = result
         return self._net_version
 

--- a/pons/_contract_abi.py
+++ b/pons/_contract_abi.py
@@ -94,7 +94,11 @@ class Signature:
             normalized_values = decode_single(self.canonical_form, value_bytes)
         except BackendDecodingError as exc:
             # wrap possible `eth_abi` errors
-            raise ABIDecodingError(str(exc)) from exc
+            message = (
+                f"Could not decode the return value "
+                f"with the expected signature {self.canonical_form}: {str(exc)}"
+            )
+            raise ABIDecodingError(message) from exc
 
         return [tp.denormalize(result) for result, tp in zip(normalized_values, self._types)]
 

--- a/pons/_contract_abi.py
+++ b/pons/_contract_abi.py
@@ -17,8 +17,15 @@ from typing import (
 
 from eth_utils import keccak
 from eth_abi import encode_single, decode_single
+from eth_abi.exceptions import DecodingError as BackendDecodingError
 
 from ._abi_types import Type, dispatch_types, dispatch_type
+
+
+class ABIDecodingError(Exception):
+    """
+    Raised on an error when decoding a value in an Eth ABI encoded bytestring.
+    """
 
 
 class Signature:
@@ -83,7 +90,12 @@ class Signature:
         """
         Decodes the packed bytestring into a list of values.
         """
-        normalized_values = decode_single(self.canonical_form, value_bytes)
+        try:
+            normalized_values = decode_single(self.canonical_form, value_bytes)
+        except BackendDecodingError as exc:
+            # wrap possible `eth_abi` errors
+            raise ABIDecodingError(str(exc)) from exc
+
         return [tp.denormalize(result) for result, tp in zip(normalized_values, self._types)]
 
     def __str__(self):

--- a/pons/_entities.py
+++ b/pons/_entities.py
@@ -5,7 +5,7 @@ from typing import NamedTuple, Union, Optional
 from eth_utils import to_checksum_address, to_canonical_address
 
 
-class DecodingError(Exception):
+class RPCDecodingError(Exception):
     """
     Raised on an error when decoding a value in an RPC response.
     """
@@ -71,7 +71,7 @@ class Amount:
 
     @classmethod
     def decode(cls, val: str) -> "Amount":
-        # `decode_data` will raise DecodingError on any error,
+        # `decode_data` will raise RPCDecodingError on any error,
         # and if it succeeds, constructor won't raise anything -
         # the value is already guaranteed to be `int` and non-negative
         return cls(decode_quantity(val))
@@ -163,7 +163,7 @@ class Address:
         try:
             return cls(decode_data(val))
         except ValueError as exc:
-            raise DecodingError(str(exc)) from exc
+            raise RPCDecodingError(str(exc)) from exc
 
     def __str__(self):
         return self.checksum
@@ -215,7 +215,7 @@ class TxHash:
         try:
             return TxHash(decode_data(val))
         except ValueError as exc:
-            raise DecodingError(str(exc)) from exc
+            raise RPCDecodingError(str(exc)) from exc
 
     def __bytes__(self):
         return self._tx_hash
@@ -262,21 +262,21 @@ def encode_block(val: Union[int, Block]) -> str:
 
 def decode_quantity(val: str) -> int:
     if not isinstance(val, str):
-        raise DecodingError("Encoded quantity must be a string")
+        raise RPCDecodingError("Encoded quantity must be a string")
     if not val.startswith("0x"):
-        raise DecodingError("Encoded quantity must start with `0x`")
+        raise RPCDecodingError("Encoded quantity must start with `0x`")
     try:
         return int(val, 16)
     except ValueError as exc:
-        raise DecodingError(f"Could not convert encoded quantity to an integer: {exc}") from exc
+        raise RPCDecodingError(f"Could not convert encoded quantity to an integer: {exc}") from exc
 
 
 def decode_data(val: str) -> bytes:
     if not isinstance(val, str):
-        raise DecodingError("Encoded data must be a string")
+        raise RPCDecodingError("Encoded data must be a string")
     if not val.startswith("0x"):
-        raise DecodingError("Encoded data must start with `0x`")
+        raise RPCDecodingError("Encoded data must start with `0x`")
     try:
         return bytes.fromhex(val[2:])
     except ValueError as exc:
-        raise DecodingError(f"Could not convert encoded data to bytes: {exc}") from exc
+        raise RPCDecodingError(f"Could not convert encoded data to bytes: {exc}") from exc

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -191,7 +191,12 @@ async def test_eth_call_decoding_error(test_provider, session, compiled_contract
     )
     wrong_contract = DeployedContract(abi=wrong_abi, address=deployed_contract.address)
 
-    with pytest.raises(ABIDecodingError, match="Tried to read 32 bytes.  Only got 0 bytes"):
+    expected_message = (
+        r"Could not decode the return value with the expected signature \(uint256,uint256\): "
+        r"Tried to read 32 bytes.  Only got 0 bytes"
+    )
+
+    with pytest.raises(ABIDecodingError, match=expected_message):
         await session.eth_call(wrong_contract.read.getState(456))
 
 

--- a/tests/test_contract_abi.py
+++ b/tests/test_contract_abi.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pons import abi, Constructor, ReadMethod, WriteMethod, Fallback, Receive, ContractABI
-from pons._contract_abi import Signature
+from pons._contract_abi import Signature, ABIDecodingError
 
 
 def test_signature_from_dict():
@@ -158,6 +158,19 @@ def test_read_method_single_output():
 
     encoded_bytes = b"\x00" * 31 + b"\x01"
     assert read.decode_output(encoded_bytes) == 1
+
+
+async def test_decoding_error():
+    """
+    Checks handling of an event when data returned by `eth_call` does not match
+    the output signature of the method.
+    """
+    read = ReadMethod(name="someMethod", inputs=[], outputs=[abi.uint(256), abi.uint(256)])
+
+    encoded_bytes = b"\x00" * 31 + b"\x01"  # Only one uint256
+
+    with pytest.raises(ABIDecodingError, match="Tried to read 32 bytes.  Only got 0 bytes"):
+        read.decode_output(encoded_bytes)
 
 
 def test_read_method_errors():

--- a/tests/test_contract_abi.py
+++ b/tests/test_contract_abi.py
@@ -169,7 +169,12 @@ async def test_decoding_error():
 
     encoded_bytes = b"\x00" * 31 + b"\x01"  # Only one uint256
 
-    with pytest.raises(ABIDecodingError, match="Tried to read 32 bytes.  Only got 0 bytes"):
+    expected_message = (
+        r"Could not decode the return value with the expected signature \(uint256,uint256\): "
+        r"Tried to read 32 bytes.  Only got 0 bytes"
+    )
+
+    with pytest.raises(ABIDecodingError, match=expected_message):
         read.decode_output(encoded_bytes)
 
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -9,7 +9,7 @@ from pons._entities import (
     encode_block,
     decode_quantity,
     decode_data,
-    DecodingError,
+    RPCDecodingError,
 )
 
 
@@ -117,7 +117,7 @@ def test_address():
     with pytest.raises(ValueError):
         Address.from_hex(random_addr_checksum[:-1])
 
-    with pytest.raises(DecodingError, match="Address must be 20 bytes long, got 19"):
+    with pytest.raises(RPCDecodingError, match="Address must be 20 bytes long, got 19"):
         Address.decode("0x" + random_addr[:-1].hex())
 
 
@@ -142,7 +142,7 @@ def test_tx_hash():
     with pytest.raises(ValueError, match="Transaction hash must be 32 bytes long, got 31"):
         TxHash(tx_hash_bytes[:-1])
 
-    with pytest.raises(DecodingError, match="Transaction hash must be 32 bytes long, got 31"):
+    with pytest.raises(RPCDecodingError, match="Transaction hash must be 32 bytes long, got 31"):
         TxHash.decode("0x" + tx_hash_bytes[:-1].hex())
 
 
@@ -150,13 +150,13 @@ def test_encode_decode_quantity():
     assert encode_quantity(100) == "0x64"
     assert decode_quantity("0x64") == 100
 
-    with pytest.raises(DecodingError, match="Encoded quantity must be a string"):
+    with pytest.raises(RPCDecodingError, match="Encoded quantity must be a string"):
         decode_quantity(100)
 
-    with pytest.raises(DecodingError, match="Encoded quantity must start with `0x`"):
+    with pytest.raises(RPCDecodingError, match="Encoded quantity must start with `0x`"):
         decode_quantity("616263")
 
-    with pytest.raises(DecodingError, match="Could not convert encoded quantity to an integer"):
+    with pytest.raises(RPCDecodingError, match="Could not convert encoded quantity to an integer"):
         decode_quantity("0xefgh")
 
 
@@ -164,13 +164,13 @@ def test_encode_decode_data():
     assert encode_data(b"abc") == "0x616263"
     assert decode_data("0x616263") == b"abc"
 
-    with pytest.raises(DecodingError, match="Encoded data must be a string"):
+    with pytest.raises(RPCDecodingError, match="Encoded data must be a string"):
         decode_data(616263)
 
-    with pytest.raises(DecodingError, match="Encoded data must start with `0x`"):
+    with pytest.raises(RPCDecodingError, match="Encoded data must start with `0x`"):
         decode_data("616263")
 
-    with pytest.raises(DecodingError, match="Could not convert encoded data to bytes"):
+    with pytest.raises(RPCDecodingError, match="Could not convert encoded data to bytes"):
         decode_data("0xefgh")
 
 


### PR DESCRIPTION
Adds an `ABIDecodingError` raised if `pons` cannot match the bytestring returned by `eth_call` with the contract ABI. Fixes #8

Making it an "Added" entry and not "Changed" in the changelog, because the behavior in this case was not previously documented.