### PR TITLE
Support gas override in `transfer()`, `transact()`, and `deploy()`

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,10 +10,12 @@ Added
 
 - ``anyio`` support instead of just ``trio``. (PR_27_)
 - Raise ``ABIDecodingError`` on mismatch between the declared contract ABI and the bytestring returned from ``ethCall``. (PR_29_)
+- Support for gas overrides in ``transfer()``, ``transact()``, and ``deploy()``. (PR_30_)
 
 
 .. _PR_27: https://github.com/fjarri/pons/pull/27
 .. _PR_29: https://github.com/fjarri/pons/pull/29
+.. _PR_30: https://github.com/fjarri/pons/pull/30
 
 
 0.4.0 (23-04-2022)


### PR DESCRIPTION
Fixes #18