### PR TITLE
Internal encoding/decoding refactor

### DIFF
--- a/pons/__init__.py
+++ b/pons/__init__.py
@@ -1,4 +1,5 @@
 from . import abi
+from ._abi_types import ABIDecodingError
 from ._client import (
     Client,
     RemoteError,
@@ -9,7 +10,6 @@ from ._client import (
     ProviderError,
 )
 from ._contract_abi import (
-    ABIDecodingError,
     ContractABI,
     Constructor,
     ReadMethod,

--- a/pons/_abi_types.py
+++ b/pons/_abi_types.py
@@ -40,7 +40,7 @@ class Type(ABC):
         ...
 
     @abstractmethod
-    def normalize(self, val) -> Any:
+    def _normalize(self, val) -> Any:
         """
         Checks and possibly normalizes the value making it ready to be passed
         to ``encode()`` for encoding.
@@ -48,7 +48,7 @@ class Type(ABC):
         ...
 
     @abstractmethod
-    def denormalize(self, val) -> Any:
+    def _denormalize(self, val) -> Any:
         """
         Checks the result of ``decode()``
         and wraps it in a specific type, if applicable.
@@ -80,7 +80,7 @@ class Type(ABC):
 
         # Before doing anything, normalize the value,
         # this will check that ensure the constituent values are actually valid.
-        return self._encode_to_topic_outer(self.normalize(val))
+        return self._encode_to_topic_outer(self._normalize(val))
 
     def _encode_to_topic_outer(self, val) -> bytes:
         """
@@ -110,7 +110,7 @@ class Type(ABC):
 
         # By default it's just the decoding of the value type.
         # May be overridden.
-        return self.denormalize(self.decode(val))
+        return self._denormalize(self.decode(val))
 
     def __str__(self):
         return self.canonical_form
@@ -157,11 +157,11 @@ class UInt(Type):
                 f"under {self._bits} bits, got {val}"
             )
 
-    def normalize(self, val):
+    def _normalize(self, val):
         self._check_val(val)
         return int(val)
 
-    def denormalize(self, val):
+    def _denormalize(self, val):
         self._check_val(val)
         return val
 
@@ -196,11 +196,11 @@ class Int(Type):
                 f"under {self._bits} bits, got {val}"
             )
 
-    def normalize(self, val):
+    def _normalize(self, val):
         self._check_val(val)
         return val
 
-    def denormalize(self, val):
+    def _denormalize(self, val):
         self._check_val(val)
         return val
 
@@ -231,11 +231,11 @@ class Bytes(Type):
         if self._size is not None and len(val) != self._size:
             raise ValueError(f"Expected {self._size} bytes, got {len(val)}")
 
-    def normalize(self, val):
+    def _normalize(self, val):
         self._check_val(val)
         return val
 
-    def denormalize(self, val):
+    def _denormalize(self, val):
         self._check_val(val)
         return val
 
@@ -277,7 +277,7 @@ class AddressType(Type):
     def canonical_form(self):
         return "address"
 
-    def normalize(self, val):
+    def _normalize(self, val):
         if not isinstance(val, Address):
             raise TypeError(
                 f"`address` must correspond to an `Address`-type value, "
@@ -285,7 +285,7 @@ class AddressType(Type):
             )
         return bytes(val)
 
-    def denormalize(self, val):
+    def _denormalize(self, val):
         return Address.from_hex(val)
 
     def __eq__(self, other):
@@ -307,11 +307,11 @@ class String(Type):
                 f"`string` must correspond to a `str`-type value, got {type(val).__name__}"
             )
 
-    def normalize(self, val):
+    def _normalize(self, val):
         self._check_val(val)
         return val
 
-    def denormalize(self, val):
+    def _denormalize(self, val):
         self._check_val(val)
         return val
 
@@ -346,11 +346,11 @@ class Bool(Type):
                 f"`bool` must correspond to a `bool`-type value, got {type(val).__name__}"
             )
 
-    def normalize(self, val):
+    def _normalize(self, val):
         self._check_val(val)
         return val
 
-    def denormalize(self, val):
+    def _denormalize(self, val):
         self._check_val(val)
         return val
 
@@ -379,13 +379,13 @@ class Array(Type):
         if self._size is not None and len(val) != self._size:
             raise ValueError(f"Expected {self._size} elements, got {len(val)}")
 
-    def normalize(self, val):
+    def _normalize(self, val):
         self._check_val(val)
-        return [self._element_type.normalize(item) for item in val]
+        return [self._element_type._normalize(item) for item in val]
 
-    def denormalize(self, val):
+    def _denormalize(self, val):
         self._check_val(val)
-        return [self._element_type.denormalize(item) for item in val]
+        return [self._element_type._denormalize(item) for item in val]
 
     def _encode_to_topic_outer(self, val):
         return keccak(self._encode_to_topic_inner(val))
@@ -422,20 +422,20 @@ class Struct(Type):
         if len(val) != len(self._fields):
             raise ValueError(f"Expected {len(self._fields)} elements, got {len(val)}")
 
-    def normalize(self, val):
+    def _normalize(self, val):
         if isinstance(val, Mapping):
             if val.keys() != self._fields.keys():
                 raise ValueError(
                     f"Expected fields {list(self._fields.keys())}, got {list(val.keys())}"
                 )
-            return [tp.normalize(val[name]) for name, tp in self._fields.items()]
+            return [tp._normalize(val[name]) for name, tp in self._fields.items()]
         else:
             self._check_val(val)
-            return [tp.normalize(item) for item, tp in zip(val, self._fields.values())]
+            return [tp._normalize(item) for item, tp in zip(val, self._fields.values())]
 
-    def denormalize(self, val):
+    def _denormalize(self, val):
         self._check_val(val)
-        return {name: tp.denormalize(item) for item, (name, tp) in zip(val, self._fields.items())}
+        return {name: tp._denormalize(item) for item, (name, tp) in zip(val, self._fields.items())}
 
     def _encode_to_topic_outer(self, val):
         return keccak(self._encode_to_topic_inner(val))
@@ -529,8 +529,11 @@ def encode_args(*types_and_args: Tuple[Type, Any]) -> bytes:
         types, args = zip(*types_and_args)
     else:
         types, args = (), ()
-    return encode_single(canonical_signature(types), args)
+    return encode_single(
+        canonical_signature(types), tuple(tp._normalize(arg) for tp, arg in zip(types, args))
+    )
 
 
 def decode_args(types: Iterable[Type], data: bytes) -> Tuple[Any, ...]:
-    return decode_abi(canonical_signature(types), data)
+    values = decode_abi(canonical_signature(types), data)
+    return tuple(tp._denormalize(value) for tp, value in zip(types, values))

--- a/tests/test_abi_types.py
+++ b/tests/test_abi_types.py
@@ -16,8 +16,8 @@ from pons._abi_types import (
 
 def test_uint():
     for val in [0, 255, 10]:
-        assert abi.uint(8).normalize(val) == val
-        assert abi.uint(8).denormalize(val) == val
+        assert abi.uint(8)._normalize(val) == val
+        assert abi.uint(8)._denormalize(val) == val
 
     assert abi.uint(256).canonical_form == "uint256"
     assert abi.uint(8) == abi.uint(8)
@@ -28,25 +28,25 @@ def test_uint():
             abi.uint(bit_size)
 
     with pytest.raises(TypeError, match="`uint128` must correspond to an integer, got bool"):
-        abi.uint(128).normalize(True)
+        abi.uint(128)._normalize(True)
     with pytest.raises(TypeError, match="`uint128` must correspond to an integer, got str"):
-        abi.uint(128).normalize("abc")
+        abi.uint(128)._normalize("abc")
     with pytest.raises(
         ValueError, match="`uint128` must correspond to a non-negative integer, got -1"
     ):
-        abi.uint(128).normalize(-1)
+        abi.uint(128)._normalize(-1)
     with pytest.raises(
         ValueError,
         match="`uint128` must correspond to an unsigned integer under 128 bits, got "
         + str(2**128),
     ):
-        abi.uint(128).normalize(2**128)
+        abi.uint(128)._normalize(2**128)
 
 
 def test_int():
     for val in [0, 127, -128, 10]:
-        assert abi.int(8).normalize(val) == val
-        assert abi.int(8).denormalize(val) == val
+        assert abi.int(8)._normalize(val) == val
+        assert abi.int(8)._denormalize(val) == val
 
     assert abi.int(256).canonical_form == "int256"
     assert abi.int(8) == abi.int(8)
@@ -57,27 +57,27 @@ def test_int():
             abi.int(bit_size)
 
     with pytest.raises(TypeError, match="`int128` must correspond to an integer, got bool"):
-        abi.int(128).normalize(True)
+        abi.int(128)._normalize(True)
     with pytest.raises(TypeError, match="`int128` must correspond to an integer, got str"):
-        abi.int(128).normalize("abc")
+        abi.int(128)._normalize("abc")
     with pytest.raises(
         ValueError,
         match="`int128` must correspond to a signed integer under 128 bits, got "
         + str(-(2**127) - 1),
     ):
-        abi.int(128).normalize(-(2**127) - 1)
+        abi.int(128)._normalize(-(2**127) - 1)
     with pytest.raises(
         ValueError,
         match="`int128` must correspond to a signed integer under 128 bits, got " + str(2**127),
     ):
-        abi.int(128).normalize(2**127)
+        abi.int(128)._normalize(2**127)
 
 
 def test_bytes():
-    assert abi.bytes(3).normalize(b"foo") == b"foo"
-    assert abi.bytes(3).denormalize(b"foo") == b"foo"
-    assert abi.bytes().normalize(b"foobar") == b"foobar"
-    assert abi.bytes().denormalize(b"foobar") == b"foobar"
+    assert abi.bytes(3)._normalize(b"foo") == b"foo"
+    assert abi.bytes(3)._denormalize(b"foo") == b"foo"
+    assert abi.bytes()._normalize(b"foobar") == b"foobar"
+    assert abi.bytes()._denormalize(b"foobar") == b"foobar"
 
     assert abi.bytes(3).canonical_form == "bytes3"
     assert abi.bytes().canonical_form == "bytes"
@@ -89,53 +89,53 @@ def test_bytes():
             abi.bytes(size)
 
     with pytest.raises(TypeError, match="`bytes` must correspond to a bytestring, got str"):
-        abi.bytes().normalize("foo")
+        abi.bytes()._normalize("foo")
     with pytest.raises(ValueError, match="Expected 4 bytes, got 3"):
-        abi.bytes(4).normalize(b"foo")
+        abi.bytes(4)._normalize(b"foo")
 
 
 def test_address():
     addr_bytes = b"\x01" * 20
     addr = Address(addr_bytes)
 
-    assert abi.address.normalize(addr) == addr_bytes
-    assert abi.address.denormalize(addr_bytes) == addr
+    assert abi.address._normalize(addr) == addr_bytes
+    assert abi.address._denormalize(addr_bytes) == addr
 
     assert abi.address.canonical_form == "address"
 
     with pytest.raises(
         TypeError, match="`address` must correspond to an `Address`-type value, got str"
     ):
-        abi.address.normalize("0x" + "01" * 20)
+        abi.address._normalize("0x" + "01" * 20)
 
 
 def test_string():
-    assert abi.string.normalize("foo") == "foo"
-    assert abi.string.denormalize("foo") == "foo"
+    assert abi.string._normalize("foo") == "foo"
+    assert abi.string._denormalize("foo") == "foo"
 
     assert abi.string.canonical_form == "string"
 
     with pytest.raises(
         TypeError, match="`string` must correspond to a `str`-type value, got bytes"
     ):
-        abi.string.normalize(b"foo")
+        abi.string._normalize(b"foo")
 
 
 def test_bool():
-    assert abi.bool.normalize(True) is True
-    assert abi.bool.denormalize(True) is True
+    assert abi.bool._normalize(True) is True
+    assert abi.bool._denormalize(True) is True
 
     assert abi.bool.canonical_form == "bool"
 
     with pytest.raises(TypeError, match="`bool` must correspond to a `bool`-type value, got int"):
-        abi.bool.normalize(1)
+        abi.bool._normalize(1)
 
 
 def test_array():
-    assert abi.uint(8)[2].normalize([1, 2]) == [1, 2]
-    assert abi.uint(8)[2].denormalize([1, 2]) == [1, 2]
-    assert abi.uint(8)[...].normalize([1, 2, 3]) == [1, 2, 3]
-    assert abi.uint(8)[...].denormalize([1, 2, 3]) == [1, 2, 3]
+    assert abi.uint(8)[2]._normalize([1, 2]) == [1, 2]
+    assert abi.uint(8)[2]._denormalize([1, 2]) == [1, 2]
+    assert abi.uint(8)[...]._normalize([1, 2, 3]) == [1, 2, 3]
+    assert abi.uint(8)[...]._denormalize([1, 2, 3]) == [1, 2, 3]
 
     assert abi.uint(8)[2].canonical_form == "uint8[2]"
     assert abi.uint(8)[...].canonical_form == "uint8[]"
@@ -144,9 +144,9 @@ def test_array():
     assert abi.uint(8)[...] != abi.uint(8)[2]
 
     with pytest.raises(TypeError, match="Expected an iterable, got int"):
-        abi.uint(8)[1].normalize(1)
+        abi.uint(8)[1]._normalize(1)
     with pytest.raises(ValueError, match="Expected 2 elements, got 3"):
-        abi.uint(8)[2].normalize([1, 2, 3])
+        abi.uint(8)[2]._normalize([1, 2, 3])
 
 
 def test_struct():
@@ -156,9 +156,9 @@ def test_struct():
     s1_copy = abi.struct(a=u8, b=abi.bool)
     s2 = abi.struct(b=abi.bool, a=u8)
 
-    assert s1.normalize(dict(b=True, a=1)) == [1, True]
-    assert s1.normalize([1, True]) == [1, True]
-    assert s1.denormalize([1, True]) == dict(a=1, b=True)
+    assert s1._normalize(dict(b=True, a=1)) == [1, True]
+    assert s1._normalize([1, True]) == [1, True]
+    assert s1._denormalize([1, True]) == dict(a=1, b=True)
 
     assert s1.canonical_form == "(uint8,bool)"
     assert str(s1) == "(uint8 a, bool b)"
@@ -166,11 +166,11 @@ def test_struct():
     assert s1 != s2
 
     with pytest.raises(TypeError, match="Expected an iterable, got int"):
-        s1.normalize(1)
+        s1._normalize(1)
     with pytest.raises(ValueError, match="Expected 2 elements, got 3"):
-        s1.normalize([1, True, 2])
+        s1._normalize([1, True, 2])
     with pytest.raises(ValueError, match=r"Expected fields \['a', 'b'\], got \['a', 'c'\]"):
-        s1.normalize(dict(a=1, c=True))
+        s1._normalize(dict(a=1, c=True))
 
 
 def test_type_from_abi_string():
@@ -243,10 +243,10 @@ def test_normalization_roundtrip():
     expected_normalized = [1, [2, 3], bytes(addr), [True, "abcd"]]
 
     # normalize() loses info on struct field names
-    assert struct.normalize(value) == expected_normalized
+    assert struct._normalize(value) == expected_normalized
 
     # denormalize() should recover struct field names
-    assert struct.denormalize(expected_normalized) == value
+    assert struct._denormalize(expected_normalized) == value
 
 
 def check_topic_encode_decode(tp, val, encoded_val, can_be_decoded=True):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,7 +24,7 @@ from pons import (
 from pons._abi_types import keccak, encode_args
 from pons._contract_abi import PANIC_ERROR
 from pons._client import BadResponseFormat, ProviderError, TransactionFailed
-from pons._entities import encode_data
+from pons._entities import rpc_encode_data
 from pons._provider import RPCError
 
 from .compile import compile_file
@@ -819,7 +819,9 @@ async def test_unknown_error_reasons(test_provider, session, compiled_contracts,
     def eth_estimate_gas(*args, **kwargs):
         # Invalid selector
         data = PANIC_ERROR.selector + encode_args((abi.uint(256), 888))
-        raise RPCError(ProviderError.Code.EXECUTION_ERROR, "execution reverted", encode_data(data))
+        raise RPCError(
+            ProviderError.Code.EXECUTION_ERROR, "execution reverted", rpc_encode_data(data)
+        )
 
     with monkeypatched(test_provider, "eth_estimate_gas", eth_estimate_gas):
         with pytest.raises(ContractPanic, match=r"ContractPanicReason.UNKNOWN"):
@@ -830,7 +832,9 @@ async def test_unknown_error_reasons(test_provider, session, compiled_contracts,
     def eth_estimate_gas(*args, **kwargs):
         # Invalid selector
         data = b"1234" + encode_args((abi.uint(256), 1))
-        raise RPCError(ProviderError.Code.EXECUTION_ERROR, "execution reverted", encode_data(data))
+        raise RPCError(
+            ProviderError.Code.EXECUTION_ERROR, "execution reverted", rpc_encode_data(data)
+        )
 
     with monkeypatched(test_provider, "eth_estimate_gas", eth_estimate_gas):
         with pytest.raises(
@@ -843,7 +847,7 @@ async def test_unknown_error_reasons(test_provider, session, compiled_contracts,
     def eth_estimate_gas(*args, **kwargs):
         # Invalid selector
         data = PANIC_ERROR.selector + encode_args((abi.uint(256), 0))
-        raise RPCError(12345, "execution reverted", encode_data(data))
+        raise RPCError(12345, "execution reverted", rpc_encode_data(data))
 
     with monkeypatched(test_provider, "eth_estimate_gas", eth_estimate_gas):
         with pytest.raises(ProviderError, match=r"Provider error \(12345\): execution reverted"):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -164,7 +164,7 @@ async def test_eth_call(session, compiled_contracts, root_signer):
     compiled_contract = compiled_contracts["BasicContract"]
     deployed_contract = await session.deploy(root_signer, compiled_contract.constructor(123))
     result = await session.eth_call(deployed_contract.read.getState(456))
-    assert result == [123 + 456]
+    assert result == (123 + 456,)
 
 
 async def test_eth_call_decoding_error(session, compiled_contracts, root_signer):
@@ -295,7 +295,7 @@ async def test_deploy(test_provider, session, compiled_contracts, root_signer):
     # Normal deploy
     deployed_contract = await session.deploy(root_signer, basic_contract.constructor(123))
     result = await session.eth_call(deployed_contract.read.getState(456))
-    assert result == [123 + 456]
+    assert result == (123 + 456,)
 
     with pytest.raises(ValueError, match="This constructor does not accept an associated payment"):
         await session.deploy(root_signer, basic_contract.constructor(1), Amount.ether(1))
@@ -341,7 +341,7 @@ async def test_transact(test_provider, session, compiled_contracts, root_signer)
     deployed_contract = await session.deploy(root_signer, basic_contract.constructor(123))
     await session.transact(root_signer, deployed_contract.write.setState(456))
     result = await session.eth_call(deployed_contract.read.getState(789))
-    assert result == [456 + 789]
+    assert result == (456 + 789,)
 
     with pytest.raises(ValueError, match="This method does not accept an associated payment"):
         await session.transact(root_signer, deployed_contract.write.setState(456), Amount.ether(1))

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -101,7 +101,7 @@ def test_api_binding(compiled_contracts):
     assert read_call.data_bytes == (
         compiled_contract.abi.read.getState.selector + b"\x00" * 31 + b"\x03"
     )
-    assert read_call.decode_output(b"\x00" * 31 + b"\x04") == [4]
+    assert read_call.decode_output(b"\x00" * 31 + b"\x04") == (4,)
 
     write_call = deployed_contract.write.setState(5)
     assert write_call.contract_address == address

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -1,11 +1,10 @@
 from collections import namedtuple
 from pathlib import Path
 
-from eth_abi import encode_single
-from eth_utils import keccak
 import pytest
 
 from pons import (
+    abi,
     Address,
     Constructor,
     ReadMethod,
@@ -14,6 +13,7 @@ from pons import (
     Receive,
     Event,
 )
+from pons._abi_types import keccak, encode_args
 from pons._contract import DeployedContract, BoundReadMethod, BoundWriteMethod
 from pons._entities import LogTopic
 
@@ -113,7 +113,7 @@ def test_api_binding(compiled_contracts):
     event_filter = deployed_contract.event.Foo(1, b"1234")
     assert event_filter.contract_address == address
     assert event_filter.topics == (
-        (LogTopic(encode_single("uint", 1)),),
+        (LogTopic(abi.uint(256).encode(1)),),
         (LogTopic(keccak(b"1234")),),
     )
 
@@ -122,8 +122,8 @@ def test_api_binding(compiled_contracts):
     decoded = event_filter.decode_log_entry(
         fake_log_entry(
             address=address,
-            topics=[LogTopic(encode_single("uint", 1)), LogTopic(keccak(b"1234"))],
-            data=encode_single("(bytes4,bytes)", [b"4567", b"bytestring"]),
+            topics=[LogTopic(abi.uint(256).encode(1)), LogTopic(keccak(b"1234"))],
+            data=encode_args((abi.bytes(4), b"4567"), (abi.bytes(), b"bytestring")),
         )
     )
     assert decoded == dict(x=1, y=None, u=b"4567", v=b"bytestring")

--- a/tests/test_contract_abi.py
+++ b/tests/test_contract_abi.py
@@ -31,8 +31,8 @@ def test_signature_from_dict():
     sig = Signature(dict(a=abi.uint(8), b=abi.bool))
     assert sig.canonical_form == "(uint8,bool)"
     assert str(sig) == "(uint8 a, bool b)"
-    assert sig.decode_into_list(sig.encode(1, True)) == [1, True]
-    assert sig.decode_into_list(sig.encode(b=True, a=1)) == [1, True]
+    assert sig.decode_into_tuple(sig.encode(1, True)) == (1, True)
+    assert sig.decode_into_tuple(sig.encode(b=True, a=1)) == (1, True)
     assert sig.decode_into_dict(sig.encode(b=True, a=1)) == dict(b=True, a=1)
 
 
@@ -40,7 +40,7 @@ def test_signature_from_list():
     sig = Signature([abi.uint(8), abi.bool])
     assert str(sig) == "(uint8, bool)"
     assert sig.canonical_form == "(uint8,bool)"
-    assert sig.decode_into_list(sig.encode(1, True)) == [1, True]
+    assert sig.decode_into_tuple(sig.encode(1, True)) == (1, True)
     assert sig.decode_into_dict(sig.encode(1, True)) == {"_0": 1, "_1": True}
 
 
@@ -156,7 +156,7 @@ def _check_read_method(read):
     assert rcall.data_bytes == read.selector + encoded_bytes
 
     vals = read.decode_output(encoded_bytes)
-    assert vals == [1, True]
+    assert vals == (1, True)
 
 
 def test_read_method_from_json_anonymous_outputs():

--- a/tests/test_contract_functionality.py
+++ b/tests/test_contract_functionality.py
@@ -32,7 +32,7 @@ async def test_empty_constructor(session, root_signer, compiled_contracts):
     deployed_contract = await session.deploy(root_signer, compiled_contract.constructor())
     call = deployed_contract.read.getState(123)
     result = await session.eth_call(call)
-    assert result == [1 + 123]
+    assert result == (1 + 123,)
 
 
 async def test_basics(session, root_signer, another_signer, compiled_contracts):
@@ -45,22 +45,22 @@ async def test_basics(session, root_signer, another_signer, compiled_contracts):
     deployed_contract = await session.deploy(another_signer, call)
 
     # Check the state
-    assert await session.eth_call(deployed_contract.read.v1()) == [12345]
-    assert await session.eth_call(deployed_contract.read.v2()) == [56789]
+    assert await session.eth_call(deployed_contract.read.v1()) == (12345,)
+    assert await session.eth_call(deployed_contract.read.v2()) == (56789,)
 
     # Transact with the contract
     await session.transact(another_signer, deployed_contract.write.setState(111))
-    assert await session.eth_call(deployed_contract.read.v1()) == [111]
+    assert await session.eth_call(deployed_contract.read.v1()) == (111,)
 
     # Call the contract
 
     result = await session.eth_call(deployed_contract.read.getState(123))
-    assert result == [111 + 123]
+    assert result == (111 + 123,)
 
     inner = dict(inner1=1, inner2=2)
     outer = dict(inner=inner, outer1=3)
     result = await session.eth_call(deployed_contract.read.testStructs(inner, outer))
-    assert result == [inner, outer]
+    assert result == (inner, outer)
 
 
 async def test_abi_declaration(session, root_signer, another_signer, compiled_contracts):
@@ -102,7 +102,7 @@ async def test_abi_declaration(session, root_signer, another_signer, compiled_co
     inner = dict(inner1=1, inner2=2)
     outer = dict(inner=inner, outer1=3)
     result = await session.eth_call(deployed_contract.read.testStructs(inner, outer))
-    assert result == [inner, outer]
+    assert result == (inner, outer)
 
 
 async def test_complicated_event(session, root_signer, compiled_contracts):


### PR DESCRIPTION
- isolate `eth_abi`/`eth_utils.keccak()` usage inside `_abi_types.py`
- hide `normalize()`/`denormalize()` and apply them automatically on ABI operations
- rename `encode()/`decode()` from `_entities.py` to `rpc_encode()/`rpc_decode()` to avoid confusion with ABI operations