### PR TITLE
Fix classmethod typing in `Amount` and `Address`

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -178,8 +178,16 @@ Entities
 .. autoclass:: Amount
    :members:
 
+.. class:: pons._entities.CustomAmount
+
+   A type derived from :py:class:`Amount`.
+
 .. autoclass:: Address
    :members:
+
+.. class:: pons._entities.CustomAddress
+
+   A type derived from :py:class:`Address`.
 
 .. autoclass:: Block()
    :members:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,7 +5,13 @@ Changelog
 Unreleased
 ~~~~~~~~~~
 
-Under construction.
+Fixed
+^^^^^
+
+- Fix return type of classmethods of ``Amount`` and ``Address`` to provide correct information to ``mypy`` in dependent projects. (PR_37_)
+
+
+.. _PR_37: https://github.com/fjarri/pons/pull/37
 
 
 0.4.2 (05-06-2022)

--- a/pons/_entities.py
+++ b/pons/_entities.py
@@ -99,6 +99,13 @@ class TypedQuantity:
         return f"{self.__class__.__name__}({self._value})"
 
 
+# This is force-documented as :py:class in ``api.rst``
+# because Sphinx cannot resolve typevars correctly.
+# See https://github.com/sphinx-doc/sphinx/issues/9705
+CustomAmount = TypeVar("CustomAmount", bound="Amount")
+"""A subclass of :py:class:`Amount`."""
+
+
 class Amount(TypedQuantity):
     """
     Represents a sum in the chain's native currency.
@@ -109,21 +116,21 @@ class Amount(TypedQuantity):
     """
 
     @classmethod
-    def wei(cls, value: int) -> "Amount":
+    def wei(cls: Type[CustomAmount], value: int) -> CustomAmount:
         """
         Creates a sum from the amount in wei (``10^(-18)`` of the main unit).
         """
         return cls(value)
 
     @classmethod
-    def gwei(cls, value: Union[int, float]) -> "Amount":
+    def gwei(cls: Type[CustomAmount], value: Union[int, float]) -> CustomAmount:
         """
         Creates a sum from the amount in gwei (``10^(-9)`` of the main unit).
         """
         return cls(int(10**9 * value))
 
     @classmethod
-    def ether(cls, value: Union[int, float]) -> "Amount":
+    def ether(cls: Type[CustomAmount], value: Union[int, float]) -> CustomAmount:
         """
         Creates a sum from the amount in the main currency unit.
         """
@@ -182,6 +189,13 @@ class Amount(TypedQuantity):
         return self._value <= other._value
 
 
+# This is force-documented as :py:class in ``api.rst``
+# because Sphinx cannot resolve typevars correctly.
+# See https://github.com/sphinx-doc/sphinx/issues/9705
+CustomAddress = TypeVar("CustomAddress", bound="Address")
+"""A subclass of :py:class:`Address`."""
+
+
 class Address(TypedData):
     """
     Represents an Ethereum address.
@@ -191,7 +205,7 @@ class Address(TypedData):
         return 20
 
     @classmethod
-    def from_hex(cls, address_str: str) -> "Address":
+    def from_hex(cls: Type[CustomAddress], address_str: str) -> CustomAddress:
         """
         Creates the address from a hex representation
         (with or without the ``0x`` prefix, checksummed or not).


### PR DESCRIPTION
Fixes #36

Going with a boilerplate-y solution for now, since `autodoc` cannot pick up typevars correctly (see https://github.com/sphinx-doc/sphinx/issues/9705), and in general it is unclear how to document classmethods properly in Sphinx. At least this solution satisfies `mypy`.

 