### PR TITLE
Merge ReadMethod and WriteMethod into Method

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -92,17 +92,14 @@ Contract ABI
 .. autoclass:: ContractABI
    :members:
 
+.. autoclass:: Mutability
+   :members:
+
 .. autoclass:: Constructor
    :members:
    :special-members: __call__
 
-.. autoclass:: ReadMethod
-   :show-inheritance:
-   :members:
-   :special-members: __call__
-
-.. autoclass:: WriteMethod
-   :show-inheritance:
+.. autoclass:: Method
    :members:
    :special-members: __call__
 
@@ -125,10 +122,7 @@ Secondary classes
 .. autoclass:: pons._contract_abi.ConstructorCall()
    :members:
 
-.. autoclass:: pons._contract_abi.ReadCall()
-   :members:
-
-.. autoclass:: pons._contract_abi.WriteCall()
+.. autoclass:: pons._contract_abi.MethodCall()
    :members:
 
 .. autoclass:: pons._contract_abi.EventFilter()
@@ -141,18 +135,11 @@ Secondary classes
 .. autoclass:: pons._contract.BoundConstructorCall()
    :members:
 
-.. autoclass:: pons._contract.BoundReadMethod()
+.. autoclass:: pons._contract.BoundMethod()
    :members:
    :special-members: __call__
 
-.. autoclass:: pons._contract.BoundReadCall()
-   :members:
-
-.. autoclass:: pons._contract.BoundWriteMethod()
-   :members:
-   :special-members: __call__
-
-.. autoclass:: pons._contract.BoundWriteCall()
+.. autoclass:: pons._contract.BoundMethodCall()
    :members:
 
 .. autoclass:: pons._contract.BoundEvent()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,18 +2,26 @@ Changelog
 ---------
 
 
-0.6.1 (in development)
+0.7.0 (in development)
 ~~~~~~~~~~~~~~~~~~~~~~
+
+Changed
+^^^^^^^
+
+- ``ReadMethod`` and ``WriteMethod`` were merged into ``Method`` (with the corresponding merge of ``ContractABI`` routing objects and various bound calls). (PR_50_)
+
 
 Added
 ^^^^^
 
 - ``Block.SAFE`` and ``Block.FINALIZED`` values. (PR_48_)
 - ``FallbackProvider``, two strategies for it (``CycleFallback`` and ``PriorityFallback``), and a framework for creating user-defined strategies (``FallbackStrategy`` and ``FallbackStrategyFactory``). (PR_49_)
+- ``Mutability`` enum for defining contract method mutability. (PR_50_)
 
 
 .. _PR_48: https://github.com/fjarri/pons/pull/48
 .. _PR_49: https://github.com/fjarri/pons/pull/49
+.. _PR_50: https://github.com/fjarri/pons/pull/50
 
 
 

--- a/pons/__init__.py
+++ b/pons/__init__.py
@@ -12,13 +12,13 @@ from ._client import (
 from ._contract_abi import (
     ContractABI,
     Constructor,
-    ReadMethod,
-    WriteMethod,
+    Method,
     Event,
     Error,
     Fallback,
     Receive,
     Either,
+    Mutability,
 )
 from ._contract import CompiledContract, DeployedContract
 from ._entities import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pons"
-version = "0.6.0"
+version = "0.7.0-dev"
 description = "Async RPC client for Ethereum"
 authors = [
     {name = "Bogdan Opanchuk", email = "bogdan@opanchuk.net"},

--- a/tests/TestContractFunctionality.sol
+++ b/tests/TestContractFunctionality.sol
@@ -29,6 +29,11 @@ contract Test {
         v2 = 2;
     }
 
+    function setStateAndReturn(uint256 _v1) public returns (uint256) {
+        v1 = v1 + _v1;
+        return v1;
+    }
+
     function setState(uint256 _v1) public {
         v1 = _v1;
     }

--- a/tests/provider.py
+++ b/tests/provider.py
@@ -50,7 +50,7 @@ def pyevm_errors_into_rpc_errors():
                 # raises ValueError if it is not a Python literal
                 reason_data = ast.literal_eval(reason)
                 assert isinstance(reason_data, bytes)  # sanity check
-            except ValueError:
+            except (ValueError, SyntaxError):
                 assert isinstance(reason, str)  # sanity check
                 # Bring `reason_data` to what a `Revert` instance would contain in this case
                 reason_data = _ERROR_SELECTOR + encode_args((abi.string, reason))

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -7,14 +7,13 @@ from pons import (
     abi,
     Address,
     Constructor,
-    ReadMethod,
-    WriteMethod,
+    Method,
     Fallback,
     Receive,
     Event,
 )
 from pons._abi_types import keccak, encode_args
-from pons._contract import DeployedContract, BoundReadMethod, BoundWriteMethod
+from pons._contract import DeployedContract, BoundMethod
 from pons._entities import LogTopic
 
 from .compile import compile_file
@@ -44,27 +43,27 @@ def test_abi_declaration(compiled_contracts):
     assert isinstance(cabi.receive, Receive)
     assert cabi.receive.payable
 
-    assert isinstance(cabi.read.v1, ReadMethod)
-    assert str(cabi.read.v1.inputs) == "()"
-    assert str(cabi.read.v1.outputs) == "(uint256)"
+    assert isinstance(cabi.method.v1, Method)
+    assert str(cabi.method.v1.inputs) == "()"
+    assert str(cabi.method.v1.outputs) == "(uint256)"
 
-    assert isinstance(cabi.read.getState, ReadMethod)
-    assert str(cabi.read.getState.inputs) == "(uint256 _x)"
-    assert str(cabi.read.getState.outputs) == "(uint256)"
+    assert isinstance(cabi.method.getState, Method)
+    assert str(cabi.method.getState.inputs) == "(uint256 _x)"
+    assert str(cabi.method.getState.outputs) == "(uint256)"
 
-    assert isinstance(cabi.read.testStructs, ReadMethod)
+    assert isinstance(cabi.method.testStructs, Method)
     assert (
-        str(cabi.read.testStructs.inputs)
+        str(cabi.method.testStructs.inputs)
         == "((uint256,uint256) inner_in, ((uint256,uint256),uint256) outer_in)"
     )
     assert (
-        str(cabi.read.testStructs.outputs)
+        str(cabi.method.testStructs.outputs)
         == "((uint256,uint256) inner_out, ((uint256,uint256),uint256) outer_out)"
     )
 
-    assert isinstance(cabi.write.setState, WriteMethod)
-    assert str(cabi.write.setState.inputs) == "(uint256 _v1)"
-    assert cabi.write.setState.payable
+    assert isinstance(cabi.method.setState, Method)
+    assert str(cabi.method.setState.inputs) == "(uint256 _v1)"
+    assert cabi.method.setState.payable
 
     assert isinstance(cabi.event.Foo, Event)
     assert str(cabi.event.Foo.fields) == "(uint256 indexed x, bytes indexed y, bytes4 u, bytes v)"
@@ -84,10 +83,10 @@ def test_api_binding(compiled_contracts):
 
     assert deployed_contract.address == address
     assert deployed_contract.abi == compiled_contract.abi
-    assert isinstance(deployed_contract.read.v1, BoundReadMethod)
-    assert isinstance(deployed_contract.read.getState, BoundReadMethod)
-    assert isinstance(deployed_contract.read.testStructs, BoundReadMethod)
-    assert isinstance(deployed_contract.write.setState, BoundWriteMethod)
+    assert isinstance(deployed_contract.method.v1, BoundMethod)
+    assert isinstance(deployed_contract.method.getState, BoundMethod)
+    assert isinstance(deployed_contract.method.testStructs, BoundMethod)
+    assert isinstance(deployed_contract.method.setState, BoundMethod)
 
     ctr_call = compiled_contract.constructor(1, 2)
     assert ctr_call.payable
@@ -96,18 +95,18 @@ def test_api_binding(compiled_contracts):
         compiled_contract.bytecode + b"\x00" * 31 + b"\x01" + b"\x00" * 31 + b"\x02"
     )
 
-    read_call = deployed_contract.read.getState(3)
+    read_call = deployed_contract.method.getState(3)
     assert read_call.contract_address == address
     assert read_call.data_bytes == (
-        compiled_contract.abi.read.getState.selector + b"\x00" * 31 + b"\x03"
+        compiled_contract.abi.method.getState.selector + b"\x00" * 31 + b"\x03"
     )
     assert read_call.decode_output(b"\x00" * 31 + b"\x04") == (4,)
 
-    write_call = deployed_contract.write.setState(5)
+    write_call = deployed_contract.method.setState(5)
     assert write_call.contract_address == address
     assert write_call.payable
     assert write_call.data_bytes == (
-        compiled_contract.abi.write.setState.selector + b"\x00" * 31 + b"\x05"
+        compiled_contract.abi.method.setState.selector + b"\x00" * 31 + b"\x05"
     )
 
     event_filter = deployed_contract.event.Foo(1, b"1234")

--- a/tests/test_contract_functionality.py
+++ b/tests/test_contract_functionality.py
@@ -2,15 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from pons import (
-    Amount,
-    ContractABI,
-    abi,
-    Constructor,
-    ReadMethod,
-    WriteMethod,
-    DeployedContract,
-)
+from pons import Amount, ContractABI, abi, Constructor, Method, DeployedContract, Mutability
 
 from .compile import compile_file
 
@@ -30,7 +22,7 @@ async def test_empty_constructor(session, root_signer, compiled_contracts):
     compiled_contract = compiled_contracts["NoConstructor"]
 
     deployed_contract = await session.deploy(root_signer, compiled_contract.constructor())
-    call = deployed_contract.read.getState(123)
+    call = deployed_contract.method.getState(123)
     result = await session.eth_call(call)
     assert result == (1 + 123,)
 
@@ -44,21 +36,21 @@ async def test_basics(session, root_signer, another_signer, compiled_contracts):
     deployed_contract = await session.deploy(another_signer, call)
 
     # Check the state
-    assert await session.eth_call(deployed_contract.read.v1()) == (12345,)
-    assert await session.eth_call(deployed_contract.read.v2()) == (56789,)
+    assert await session.eth_call(deployed_contract.method.v1()) == (12345,)
+    assert await session.eth_call(deployed_contract.method.v2()) == (56789,)
 
     # Transact with the contract
-    await session.transact(another_signer, deployed_contract.write.setState(111))
-    assert await session.eth_call(deployed_contract.read.v1()) == (111,)
+    await session.transact(another_signer, deployed_contract.method.setState(111))
+    assert await session.eth_call(deployed_contract.method.v1()) == (111,)
 
     # Call the contract
 
-    result = await session.eth_call(deployed_contract.read.getState(123))
+    result = await session.eth_call(deployed_contract.method.getState(123))
     assert result == (111 + 123,)
 
     inner = dict(inner1=1, inner2=2)
     outer = dict(inner=inner, outer1=3)
-    result = await session.eth_call(deployed_contract.read.testStructs(inner, outer))
+    result = await session.eth_call(deployed_contract.method.testStructs(inner, outer))
     assert result == (inner, outer)
 
 
@@ -75,11 +67,19 @@ async def test_abi_declaration(session, root_signer, another_signer, compiled_co
     outer_struct = abi.struct(inner=inner_struct, outer1=abi.uint(256))
     declared_abi = ContractABI(
         constructor=Constructor(inputs=dict(_v1=abi.uint(256), _v2=abi.uint(256))),
-        write=[WriteMethod(name="setState", inputs=dict(_v1=abi.uint(256)))],
-        read=[
-            ReadMethod(name="getState", inputs=dict(_x=abi.uint(256)), outputs=abi.uint(256)),
-            ReadMethod(
+        methods=[
+            Method(
+                name="setState", mutability=Mutability.NONPAYABLE, inputs=dict(_v1=abi.uint(256))
+            ),
+            Method(
+                name="getState",
+                mutability=Mutability.VIEW,
+                inputs=dict(_x=abi.uint(256)),
+                outputs=abi.uint(256),
+            ),
+            Method(
                 name="testStructs",
+                mutability=Mutability.VIEW,
                 inputs=dict(inner_in=inner_struct, outer_in=outer_struct),
                 outputs=dict(inner_out=inner_struct, outer_out=outer_struct),
             ),
@@ -90,16 +90,16 @@ async def test_abi_declaration(session, root_signer, another_signer, compiled_co
 
     # Transact with the contract
     await session.transfer(root_signer, another_signer.address, Amount.ether(10))
-    await session.transact(another_signer, deployed_contract.write.setState(111))
+    await session.transact(another_signer, deployed_contract.method.setState(111))
 
     # Call the contract
 
-    result = await session.eth_call(deployed_contract.read.getState(123))
+    result = await session.eth_call(deployed_contract.method.getState(123))
     assert result == 111 + 123  # Note the lack of `[]` - we declared outputs as a single value
 
     inner = dict(inner1=1, inner2=2)
     outer = dict(inner=inner, outer1=3)
-    result = await session.eth_call(deployed_contract.read.testStructs(inner, outer))
+    result = await session.eth_call(deployed_contract.method.testStructs(inner, outer))
     assert result == (inner, outer)
 
 
@@ -123,7 +123,7 @@ async def test_complicated_event(session, root_signer, compiled_contracts):
 
     log_filter1 = await session.eth_new_filter(event_filter=event_filter)  # filter by topics
     log_filter2 = await session.eth_new_filter()  # collect everything
-    await session.transact(root_signer, contract.write.emitComplicated())
+    await session.transact(root_signer, contract.method.emitComplicated())
     entries_filtered = await session.eth_get_filter_changes(log_filter1)
     entries_all = await session.eth_get_filter_changes(log_filter2)
 


### PR DESCRIPTION
Since transacting methods can still be invoked in "read-only" mode, there's no reason to complicate things and have separate `ReadMethod` and `WriteMethod`.