### PR TITLE
Process unnamed arguments in JSON entries correctly

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,18 @@ Changelog
 ---------
 
 
+0.7.1 (unreleased)
+~~~~~~~~~~~~~~~~~~
+
+Fixed
+^^^^^
+
+- Process unnamed arguments in JSON entries correctly (as positional arguments). (PR_51_)
+
+
+.. _PR_51: https://github.com/fjarri/pons/pull/51
+
+
 0.7.0 (09-07-2023)
 ~~~~~~~~~~~~~~~~~~
 

--- a/pons/_contract_abi.py
+++ b/pons/_contract_abi.py
@@ -436,6 +436,9 @@ class Event:
 
         name = event_entry["name"]
         fields = dispatch_types(event_entry["inputs"])
+        if isinstance(fields, list):
+            raise ValueError("Event fields must be named")
+
         indexed = {input_["name"] for input_ in event_entry["inputs"] if input_["indexed"]}
 
         return cls(name=name, fields=fields, indexed=indexed, anonymous=event_entry["anonymous"])
@@ -530,6 +533,8 @@ class Error:
 
         name = error_entry["name"]
         fields = dispatch_types(error_entry["inputs"])
+        if isinstance(fields, list):
+            raise ValueError("Error fields must be named")
 
         return cls(name=name, fields=fields)
 

--- a/tests/test_abi_types.py
+++ b/tests/test_abi_types.py
@@ -212,14 +212,29 @@ def test_dispatch_types():
         dict(name="param2", type="uint8"),
         dict(name="param1", type="uint16[2]"),
     ]
+
+    assert dispatch_types(entries) == dict(param2=abi.uint(8), param1=abi.uint(16)[2])
+
     # Check that the order is preserved, too
     assert list(dispatch_types(entries).items()) == [
         ("param2", abi.uint(8)),
         ("param1", abi.uint(16)[2]),
     ]
 
+    # Note that if all the names are empty, it is treated as a list of positional arguments
+    assert dispatch_types([dict(name="", type="uint8"), dict(name="", type="uint16[2]")]) == [
+        abi.uint(8),
+        abi.uint(16)[2],
+    ]
+
+    # For an empty argument list we choose to resolve it as an empty dictionary, for certainty.
+    assert dispatch_types([]) == {}
+
+    with pytest.raises(ValueError, match="Arguments must be either all named or all unnamed"):
+        dispatch_types([dict(name="foo", type="uint8"), dict(name="", type="uint16[2]")])
+
     with pytest.raises(ValueError, match="All ABI entries must have distinct names"):
-        dispatch_types([dict(name="", type="uint8"), dict(name="", type="uint16[2]")])
+        dispatch_types([dict(name="foo", type="uint8"), dict(name="foo", type="uint16[2]")])
 
 
 def test_making_arrays():

--- a/tests/test_contract_abi.py
+++ b/tests/test_contract_abi.py
@@ -600,6 +600,19 @@ def test_event_errors():
     # This works
     Event("Foo", dict(a=uint8, b=uint8, c=uint8, d=uint8, e=uint8), indexed={"a", "b", "c"})
 
+    with pytest.raises(ValueError, match="Event fields must be named"):
+        Event.from_json(
+            dict(
+                anonymous=True,
+                inputs=[
+                    dict(indexed=True, internalType="address", name="", type="address"),
+                    dict(indexed=False, internalType="uint8", name="", type="uint8"),
+                ],
+                name="Foo",
+                type="event",
+            )
+        )
+
 
 def test_error_from_json():
     error = Error.from_json(
@@ -621,6 +634,18 @@ def test_error_from_json():
         match="Error object must be created from a JSON entry with type='error'",
     ):
         Error.from_json(dict(type="constructor"))
+
+    with pytest.raises(ValueError, match="Error fields must be named"):
+        Error.from_json(
+            dict(
+                inputs=[
+                    dict(internalType="address", name="", type="address"),
+                    dict(internalType="bytes", name="", type="bytes"),
+                ],
+                name="Foo",
+                type="error",
+            )
+        )
 
 
 def test_error_init():


### PR DESCRIPTION
If `name` fields are empty, treat it as a positional argument list