### PR TITLE
Add "return value"-like functionality to `transact()`, based on events

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,12 @@ Changelog
 0.7.1 (unreleased)
 ~~~~~~~~~~~~~~~~~~
 
+Added
+^^^^^
+
+- `Client.transact()` takes an optional `return_events` argument, allowing one to get "return values" from the transaction via events. (PR_52_)
+
+
 Fixed
 ^^^^^
 
@@ -12,6 +18,7 @@ Fixed
 
 
 .. _PR_51: https://github.com/fjarri/pons/pull/51
+.. _PR_52: https://github.com/fjarri/pons/pull/52
 
 
 0.7.0 (09-07-2023)

--- a/tests/TestClient.sol
+++ b/tests/TestClient.sol
@@ -47,8 +47,22 @@ contract BasicContract {
     function deposit2(bytes4 id) public payable {
         emit Deposit2(msg.sender, id, msg.value, msg.value + 1);
     }
-}
 
+    event Event1(
+        uint32 indexed value
+    );
+
+    event Event2(
+        uint32 value
+    );
+
+    function emitMultipleEvents(uint32 x) public {
+        emit Event1(x);
+        emit Event1(x + 1);
+        emit Event2(x + 2);
+        emit Event2(x + 3);
+    }
+}
 
 contract PayableConstructor {
     uint256 public state;


### PR DESCRIPTION
`Client.transact()` takes an optional `return_events` argument, allowing one to get "return values" from the transaction via events.