### PR TITLE
Expose several types from the top level

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,7 +10,7 @@ Clients
 .. autoclass:: Client
    :members:
 
-.. autoclass:: pons._client.ClientSession()
+.. autoclass:: ClientSession()
    :members:
 
 
@@ -119,34 +119,37 @@ Contract ABI
 Secondary classes
 -----------------
 
-.. autoclass:: pons._contract_abi.ConstructorCall()
+The instances of these classes are not created by the user directly, but rather found as return values, or attributes of other objects.
+
+
+.. autoclass:: ConstructorCall()
    :members:
 
-.. autoclass:: pons._contract_abi.MethodCall()
+.. autoclass:: MethodCall()
    :members:
 
-.. autoclass:: pons._contract_abi.EventFilter()
+.. autoclass:: EventFilter()
    :members:
 
-.. autoclass:: pons._contract.BoundConstructor()
-   :members:
-   :special-members: __call__
-
-.. autoclass:: pons._contract.BoundConstructorCall()
-   :members:
-
-.. autoclass:: pons._contract.BoundMethod()
+.. autoclass:: BoundConstructor()
    :members:
    :special-members: __call__
 
-.. autoclass:: pons._contract.BoundMethodCall()
+.. autoclass:: BoundConstructorCall()
    :members:
 
-.. autoclass:: pons._contract.BoundEvent()
+.. autoclass:: BoundMethod()
    :members:
    :special-members: __call__
 
-.. autoclass:: pons._contract.BoundEventFilter()
+.. autoclass:: BoundMethodCall()
+   :members:
+
+.. autoclass:: BoundEvent()
+   :members:
+   :special-members: __call__
+
+.. autoclass:: BoundEventFilter()
    :members:
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,8 @@ Changelog
 Added
 ^^^^^
 
-- `Client.transact()` takes an optional `return_events` argument, allowing one to get "return values" from the transaction via events. (PR_52_)
+- ``Client.transact()`` takes an optional ``return_events`` argument, allowing one to get "return values" from the transaction via events. (PR_52_)
+- Exposed ``ClientSession``, ``ConstructorCall``, ``MethodCall``, ``EventFilter``, ``BoundConstructor``, ``BoundConstructorCall``, ``BoundMethod``, ``BoundMethodCall``, ``BoundEvent``, ``BoundEventFilter`` from the top level. (PR_53_)
 
 
 Fixed
@@ -19,6 +20,7 @@ Fixed
 
 .. _PR_51: https://github.com/fjarri/pons/pull/51
 .. _PR_52: https://github.com/fjarri/pons/pull/52
+.. _PR_53: https://github.com/fjarri/pons/pull/53
 
 
 0.7.0 (09-07-2023)

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -17,7 +17,7 @@ All calls to the provider in ``pons`` happen within a session.
 It translates to the usage of a single session in the backend HTTP request library, so the details are implementation-dependent, but in general it means that multiple requests will happen faster.
 For example, in a session an SSL handshake only happens once, and it is a somewhat slow process.
 
-Correspondingly, all the main functionality of the library is concentrated in the :py:class:`~pons._client.ClientSession` class.
+Correspondingly, all the main functionality of the library is concentrated in the :py:class:`~pons.ClientSession` class.
 
 
 Signers
@@ -156,7 +156,7 @@ Deploying contracts
 
 In order to deploy a contract one needs its ABI and bytecode.
 At the moment ``pons`` does not expose the compiler interface, so it has to come from a third party library, for example `py-solcx <https://solcx.readthedocs.io/en/latest/>`_.
-With that, create a :py:class:`~pons.CompiledContract` object and use :py:meth:`~pons._client.ClientSession.deploy`:
+With that, create a :py:class:`~pons.CompiledContract` object and use :py:meth:`~pons.ClientSession.deploy`:
 
 ::
 
@@ -178,7 +178,7 @@ Interacting with deployed contracts
 A :py:class:`~pons.DeployedContract` object wraps all ABI method objects into "bound" state, similarly to how Python methods are bound to class instances.
 It means that all the method calls created from this object have the contract address inside them, so that it does not need to be provided every time.
 
-For example, to call a non-mutating contract method via :py:meth:`~pons._client.ClientSession.eth_call`:
+For example, to call a non-mutating contract method via :py:meth:`~pons.ClientSession.eth_call`:
 
 ::
 

--- a/pons/__init__.py
+++ b/pons/__init__.py
@@ -2,6 +2,7 @@ from . import abi
 from ._abi_types import ABIDecodingError
 from ._client import (
     Client,
+    ClientSession,
     RemoteError,
     ContractPanic,
     ContractLegacyError,
@@ -12,15 +13,27 @@ from ._client import (
 from ._contract_abi import (
     ContractABI,
     Constructor,
+    ConstructorCall,
     Method,
+    MethodCall,
     Event,
+    EventFilter,
     Error,
     Fallback,
     Receive,
     Either,
     Mutability,
 )
-from ._contract import CompiledContract, DeployedContract
+from ._contract import (
+    BoundConstructor,
+    BoundConstructorCall,
+    BoundMethod,
+    BoundMethodCall,
+    BoundEvent,
+    BoundEventFilter,
+    CompiledContract,
+    DeployedContract,
+)
 from ._entities import (
     Amount,
     Address,


### PR DESCRIPTION
This helps with some advanced usage, e.g. wrapping `Client` into specialized clients, or making contract mocks.