### PR TITLE
Fixing the handling of `msg.signer` in contracts

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -133,7 +133,7 @@ Testing utilities
 
 .. autoclass:: LocalProvider
    :show-inheritance:
-   :members: disable_auto_mine_transactions, enable_auto_mine_transactions, take_snapshot, revert_to_snapshot
+   :members: disable_auto_mine_transactions, enable_auto_mine_transactions, take_snapshot, revert_to_snapshot, add_account
 
 .. autoclass:: HTTPProviderServer
    :members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -88,6 +88,7 @@ Signers
    :members:
 
 .. autoclass:: AccountSigner
+   :members:
    :show-inheritance:
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,7 @@ Added
 - ``LocalProvider.take_snapshot()`` and ``revert_to_snapshot()``. (PR_61_)
 - ``AccountSigner.private_key`` property. (PR_62_)
 - ``LocalProvider.add_account()`` method. (PR_62_)
+- An optional ``sender_address`` parameter of ``ClientSession.eth_call()``. (PR_62_)
 
 
 Fixed

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,7 @@ Added
 - Expose ``HTTPProviderServer``, ``LocalProvider``, ``compile_contract_file`` that can be used for tests of Ethereum-using applications. These are gated behind optional features. (PR_54_)
 - ``LocalProvider.take_snapshot()`` and ``revert_to_snapshot()``. (PR_61_)
 - ``AccountSigner.private_key`` property. (PR_62_)
+- ``LocalProvider.add_account()`` method. (PR_62_)
 
 
 Fixed

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Changed
 - Added an explicit ``typing_extensions`` dependency. (PR_57_)
 - Various boolean arguments are now keyword-only to prevent usage errors. (PR_57_)
 - Field names clashing with Python built-ins (``hash``, ``type``, ``id``) are suffixed with an underscore. (PR_57_)
+- ``AccountSigner`` takes ``LocalSigner`` specifically and not just any ``BaseSigner``. (PR_62_)
 
 
 Added
@@ -37,6 +38,7 @@ Fixed
 .. _PR_57: https://github.com/fjarri/pons/pull/57
 .. _PR_59: https://github.com/fjarri/pons/pull/59
 .. _PR_61: https://github.com/fjarri/pons/pull/61
+.. _PR_62: https://github.com/fjarri/pons/pull/62
 
 
 0.7.0 (09-07-2023)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ Changed
 - Various boolean arguments are now keyword-only to prevent usage errors. (PR_57_)
 - Field names clashing with Python built-ins (``hash``, ``type``, ``id``) are suffixed with an underscore. (PR_57_)
 - ``AccountSigner`` takes ``LocalSigner`` specifically and not just any ``BaseSigner``. (PR_62_)
+- ``ClientSession.estimate_transact()`` and ``estimate_deploy()`` now require a ``sender_address`` parameter. (PR_62_)
 
 
 Added

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ Added
 - Support for overloaded methods via ``MultiMethod``. (PR_59_)
 - Expose ``HTTPProviderServer``, ``LocalProvider``, ``compile_contract_file`` that can be used for tests of Ethereum-using applications. These are gated behind optional features. (PR_54_)
 - ``LocalProvider.take_snapshot()`` and ``revert_to_snapshot()``. (PR_61_)
+- ``AccountSigner.private_key`` property. (PR_62_)
 
 
 Fixed

--- a/pons/_entities.py
+++ b/pons/_entities.py
@@ -43,7 +43,7 @@ class TypedData(ABC):
 
     @abstractmethod
     def _length(self) -> int:
-        ...
+        """Returns the length of this type's values representation in bytes."""
 
     def rpc_encode(self) -> str:
         return rpc_encode_data(self._value)

--- a/pons/_local_provider.py
+++ b/pons/_local_provider.py
@@ -152,6 +152,14 @@ class LocalProvider(Provider):
         """Restores the chain state to the snapshot with the given ID."""
         self._ethereum_tester.revert_to_snapshot(snapshot_id.id_)
 
+    def add_account(self, signer: AccountSigner) -> None:
+        """Registers a new signer to allow it to be used in calls and transactions."""
+        # There are gaps in how EthereumTester handles the accounts.
+        # A random signer can be used to deploy and interact with contracts without being added
+        # to the accounts, if we use `send_raw_transaction()` (which is exactly what we do).
+        # But if `eth_call()` has an explicit "from" field, it must be in the accounts.
+        self._ethereum_tester.add_account(signer.private_key.hex())
+
     def rpc(self, method: str, *args: Any) -> JSON:
         dispatch = dict(
             net_version=self.net_version,

--- a/pons/_local_provider.py
+++ b/pons/_local_provider.py
@@ -207,7 +207,13 @@ class LocalProvider(Provider):
             return cast(str, self._ethereum_tester.send_raw_transaction(tx_hex))
 
     def eth_call(self, tx: Mapping[str, Any], block: str) -> JSON:
-        # EthereumTester needs it for whatever reason
+        # Methods marked as `view` can use `msg.sender`,
+        # which will resolve to whatever was passed as "from".
+        # If nothing is passed real providers subsitute the zero address;
+        # we would like to do the same, but `EthereumTester` complains.
+        # So we're hoping here that if someone didn't supply "from",
+        # they won't be interested in its value either, so we're substituting a real address
+        # (namely, the one of the root).
         if "from" not in tx:
             tx = dict(tx)
             tx["from"] = self._default_address.rpc_encode()

--- a/pons/_local_provider.py
+++ b/pons/_local_provider.py
@@ -230,8 +230,6 @@ class LocalProvider(Provider):
 
     def eth_estimate_gas(self, tx: Mapping[str, Any], block: str) -> str:
         tx = dict(tx)
-        if "from" not in tx:
-            tx["from"] = self._default_address.rpc_encode()
         tx["value"] = rpc_decode_quantity(tx["value"])
 
         with pyevm_errors_into_rpc_errors():

--- a/pons/_signer.py
+++ b/pons/_signer.py
@@ -41,6 +41,14 @@ class AccountSigner(Signer):
         """Returns the account object used to create this signer."""
         return self._account
 
+    @property
+    def private_key(self) -> bytes:
+        """
+        Returns the private key corresponding to this signer.
+        Handle with care.
+        """
+        return bytes(self._account._private_key)  # noqa: SLF001
+
     @cached_property
     def address(self) -> Address:
         return Address.from_hex(self._account.address)

--- a/pons/_signer.py
+++ b/pons/_signer.py
@@ -3,7 +3,7 @@ from functools import cached_property
 from typing import Mapping
 
 from eth_account import Account
-from eth_account.signers.base import BaseAccount
+from eth_account.signers.local import LocalAccount
 
 from ._entities import Address
 from ._provider import JSON
@@ -26,9 +26,9 @@ class Signer(ABC):
 
 
 class AccountSigner(Signer):
-    """A signer wrapper for ``eth_account.BaseAccount`` implementors."""
+    """A signer wrapper for ``LocalAccount`` from ``eth-account`` package."""
 
-    def __init__(self, account: BaseAccount):
+    def __init__(self, account: LocalAccount):
         self._account = account
 
     @staticmethod
@@ -37,7 +37,7 @@ class AccountSigner(Signer):
         return AccountSigner(Account.create())
 
     @property
-    def account(self) -> BaseAccount:
+    def account(self) -> LocalAccount:
         """Returns the account object used to create this signer."""
         return self._account
 
@@ -46,5 +46,5 @@ class AccountSigner(Signer):
         return Address.from_hex(self._account.address)
 
     def sign_transaction(self, tx_dict: Mapping[str, JSON]) -> bytes:
-        # Ignoring the type since BaseAccount.sign_transaction is untyped
+        # Ignoring the type since `sign_transaction()` is untyped
         return bytes(self._account.sign_transaction(tx_dict).rawTransaction)  # type: ignore[no-untyped-call]

--- a/tests/TestClient.sol
+++ b/tests/TestClient.sol
@@ -27,6 +27,10 @@ contract BasicContract {
         return state + _x;
     }
 
+    function getSender() public view returns (address) {
+        return msg.sender;
+    }
+
     event Deposit(
         address indexed from,
         bytes4 indexed id,

--- a/tests/TestContractFunctionality.sol
+++ b/tests/TestContractFunctionality.sol
@@ -100,8 +100,4 @@ contract Test {
     }
 
     error MyError(address sender);
-
-    function returnSender() public {
-        revert MyError(msg.sender);
-    }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,5 +21,7 @@ def root_signer(local_provider):
 
 
 @pytest.fixture
-def another_signer():
-    return AccountSigner.create()
+def another_signer(local_provider):
+    signer = AccountSigner.create()
+    local_provider.add_account(signer)
+    return signer

--- a/tests/test_abi_types.py
+++ b/tests/test_abi_types.py
@@ -37,8 +37,7 @@ def test_uint():
         abi.uint(128)._normalize(-1)
     with pytest.raises(
         ValueError,
-        match="`uint128` must correspond to an unsigned integer under 128 bits, got "
-        + str(2**128),
+        match="`uint128` must correspond to an unsigned integer under 128 bits, got " + str(2**128),
     ):
         abi.uint(128)._normalize(2**128)
 

--- a/tests/test_contract_functionality.py
+++ b/tests/test_contract_functionality.py
@@ -34,26 +34,6 @@ async def test_empty_constructor(session, root_signer, compiled_contracts):
     assert result == (1 + 123,)
 
 
-async def test_sender(session, root_signer, another_signer, compiled_contracts):
-    """
-    A test for a bug in PyEVM, so that we notice when it's fixed:
-    https://github.com/ethereum/py-evm/issues/2129
-    (`msg.sender` is evaluated to the genesis address, not to the actual sender's address).
-    """
-    compiled_contract = compiled_contracts["Test"]
-
-    # Deploy the contract
-    call = compiled_contract.constructor(12345, 56789)
-    await session.transfer(root_signer, another_signer.address, Amount.ether(10))
-    deployed_contract = await session.deploy(another_signer, call)
-
-    with pytest.raises(ContractError) as exc:
-        await session.transact(another_signer, deployed_contract.method.returnSender())
-
-    # Here we would expect `another_signer.address` if EVM was working correctly
-    assert exc.value.data == {"sender": root_signer.address}
-
-
 async def test_basics(session, root_signer, another_signer, compiled_contracts):
     compiled_contract = compiled_contracts["Test"]
 

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -3,13 +3,7 @@ from eth_account import Account
 from pons import AccountSigner, Address
 
 
-def test_signer():
-    acc = Account.create()
-    signer = AccountSigner(acc)
-
-    assert signer.address == Address.from_hex(acc.address)
-    assert signer.account == acc
-
+def check_signer(signer):
     tx = dict(gas="0x3333", gasPrice="0x4444", nonce="0x5555", value="0x6666")
     sig = signer.sign_transaction(tx)
     assert isinstance(sig, bytes)
@@ -31,3 +25,18 @@ def test_signer():
     # 0x80 = 0x80 + 0 -> a value of 0 bytes
     # ... signature values start (v, r, s)
     assert sig.startswith(bytes.fromhex(f"f8{hex(payload_length)[2:]}8255558244448233338082666680"))
+
+
+def test_signer():
+    acc = Account.create()
+    signer = AccountSigner(acc)
+
+    assert signer.address == Address.from_hex(acc.address)
+    assert signer.account == acc
+
+    check_signer(signer)
+
+
+def test_random_signer():
+    signer = AccountSigner.create()
+    check_signer(signer)

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -33,6 +33,7 @@ def test_signer():
 
     assert signer.address == Address.from_hex(acc.address)
     assert signer.account == acc
+    assert signer.private_key == bytes(acc._private_key)
 
     check_signer(signer)
 


### PR DESCRIPTION
... and all the related issues that popped up:

- added `AccountSigner.private_key` property
- added `LocalProvider.add_account()` method
- added an optional `sender_address` parameter of `ClientSession.eth_call()`
- `AccountSigner` now takes `LocalSigner` specifically and not just any `BaseSigner`
- `ClientSession.estimate_transact()` and `estimate_deploy()` now require a `sender_address`

