### PR TITLE
Add more RPC calls

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,7 @@ Added
 - ``LocalProvider.add_account()`` method. (PR_62_)
 - An optional ``sender_address`` parameter of ``ClientSession.eth_call()``. (PR_62_)
 - Expose ``Provider`` at the top level. (PR_63_)
+- ``eth_getCode`` support (as ``ClientSession.eth_get_code()``). (PR_64_)
 
 
 Fixed
@@ -46,6 +47,7 @@ Fixed
 .. _PR_61: https://github.com/fjarri/pons/pull/61
 .. _PR_62: https://github.com/fjarri/pons/pull/62
 .. _PR_63: https://github.com/fjarri/pons/pull/63
+.. _PR_64: https://github.com/fjarri/pons/pull/64
 
 
 0.7.0 (09-07-2023)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,7 @@ Added
 - An optional ``sender_address`` parameter of ``ClientSession.eth_call()``. (PR_62_)
 - Expose ``Provider`` at the top level. (PR_63_)
 - ``eth_getCode`` support (as ``ClientSession.eth_get_code()``). (PR_64_)
+- ``eth_getStorageAt`` support (as ``ClientSession.eth_get_storage_at()``). (PR_64_)
 
 
 Fixed

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,6 +37,7 @@ Fixed
 
 - Process unnamed arguments in JSON entries correctly (as positional arguments). (PR_51_)
 - More robust error handling in HTTP provider. (PR_63_)
+- The transaction tip being set larger than the max gas price (which some providers don't like). (PR_64_)
 
 
 .. _PR_51: https://github.com/fjarri/pons/pull/51

--- a/pons/_client.py
+++ b/pons/_client.py
@@ -352,6 +352,16 @@ class ClientSession:
         )
         return rpc_decode_quantity(result)
 
+    @rpc_call("eth_getCode")
+    async def eth_get_code(
+        self, address: Address, block: Union[int, Block] = Block.LATEST
+    ) -> bytes:
+        """Calls the ``eth_getCode`` RPC method."""
+        result = await self._provider_session.rpc(
+            "eth_getCode", address.rpc_encode(), rpc_encode_block(block)
+        )
+        return rpc_decode_data(result)
+
     async def wait_for_transaction_receipt(
         self, tx_hash: TxHash, poll_latency: float = 1.0
     ) -> TxReceipt:

--- a/pons/_client.py
+++ b/pons/_client.py
@@ -362,6 +362,19 @@ class ClientSession:
         )
         return rpc_decode_data(result)
 
+    @rpc_call("eth_getStorageAt")
+    async def eth_get_storage_at(
+        self, address: Address, position: int, block: Union[int, Block] = Block.LATEST
+    ) -> bytes:
+        """Calls the ``eth_getCode`` RPC method."""
+        result = await self._provider_session.rpc(
+            "eth_getStorageAt",
+            address.rpc_encode(),
+            rpc_encode_quantity(position),
+            rpc_encode_block(block),
+        )
+        return rpc_decode_data(result)
+
     async def wait_for_transaction_receipt(
         self, tx_hash: TxHash, poll_latency: float = 1.0
     ) -> TxReceipt:

--- a/pons/_client.py
+++ b/pons/_client.py
@@ -546,7 +546,7 @@ class ClientSession:
             gas = await self.estimate_transfer(signer.address, destination_address, amount)
         # TODO (#19): implement gas strategies
         max_gas_price = await self.eth_gas_price()
-        max_tip = Amount.gwei(1)
+        max_tip = min(Amount.gwei(1), max_gas_price)
         nonce = await self.eth_get_transaction_count(signer.address, Block.LATEST)
         tx: Dict[str, Union[int, str]] = {
             "type": 2,  # EIP-2930 transaction
@@ -612,7 +612,7 @@ class ClientSession:
             gas = await self.estimate_deploy(signer.address, call, amount=amount)
         # TODO (#19): implement gas strategies
         max_gas_price = await self.eth_gas_price()
-        max_tip = Amount.gwei(1)
+        max_tip = min(Amount.gwei(1), max_gas_price)
         nonce = await self.eth_get_transaction_count(signer.address, Block.LATEST)
         tx: Dict[str, Union[int, str]] = {
             "type": 2,  # EIP-2930 transaction
@@ -664,7 +664,7 @@ class ClientSession:
             gas = await self.estimate_transact(signer.address, call, amount=amount)
         # TODO (#19): implement gas strategies
         max_gas_price = await self.eth_gas_price()
-        max_tip = Amount.gwei(1)
+        max_tip = min(Amount.gwei(1), max_gas_price)
         nonce = await self.eth_get_transaction_count(signer.address, Block.LATEST)
         tx: Dict[str, Union[int, str]] = {
             "type": 2,  # EIP-2930 transaction

--- a/pons/_local_provider.py
+++ b/pons/_local_provider.py
@@ -167,6 +167,7 @@ class LocalProvider(Provider):
             eth_getBalance=self.eth_get_balance,
             eth_getTransactionReceipt=self.eth_get_transaction_receipt,
             eth_getTransactionCount=self.eth_get_transaction_count,
+            eth_getCode=self.eth_get_code,
             eth_call=self.eth_call,
             eth_sendRawTransaction=self.eth_send_raw_transaction,
             eth_estimateGas=self.eth_estimate_gas,
@@ -201,6 +202,9 @@ class LocalProvider(Provider):
 
     def eth_get_transaction_count(self, address: str, block: str) -> str:
         return rpc_encode_quantity(self._ethereum_tester.get_nonce(address, block))
+
+    def eth_get_code(self, address: str, block: str) -> str:
+        return cast(str, self._ethereum_tester.get_code(address, block))
 
     def eth_send_raw_transaction(self, tx_hex: str) -> str:
         with pyevm_errors_into_rpc_errors():

--- a/pons/_local_provider.py
+++ b/pons/_local_provider.py
@@ -168,6 +168,7 @@ class LocalProvider(Provider):
             eth_getTransactionReceipt=self.eth_get_transaction_receipt,
             eth_getTransactionCount=self.eth_get_transaction_count,
             eth_getCode=self.eth_get_code,
+            eth_getStorageAt=self.eth_get_storage_at,
             eth_call=self.eth_call,
             eth_sendRawTransaction=self.eth_send_raw_transaction,
             eth_estimateGas=self.eth_estimate_gas,
@@ -205,6 +206,9 @@ class LocalProvider(Provider):
 
     def eth_get_code(self, address: str, block: str) -> str:
         return cast(str, self._ethereum_tester.get_code(address, block))
+
+    def eth_get_storage_at(self, address: str, position: str, block: str) -> str:
+        return cast(str, self._ethereum_tester.get_storage_at(address, position, block))
 
     def eth_send_raw_transaction(self, tx_hex: str) -> str:
         with pyevm_errors_into_rpc_errors():

--- a/tests/TestClient.sol
+++ b/tests/TestClient.sol
@@ -9,6 +9,14 @@ contract EmptyContract {
     }
 }
 
+contract Storage {
+    uint x;
+    mapping(address => uint) y;
+    constructor(uint256 _x, address _y_key, uint256 _y_val) {
+        x = _x;
+        y[_y_key] = _y_val;
+    }
+}
 
 contract BasicContract {
     uint256 public state;

--- a/tests/TestClient.sol
+++ b/tests/TestClient.sol
@@ -1,6 +1,15 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 
+contract EmptyContract {
+    uint256 public state;
+
+    constructor(uint256 _state) {
+        state = _state;
+    }
+}
+
+
 contract BasicContract {
     uint256 public state;
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -472,6 +472,17 @@ async def test_eth_get_transaction_by_hash(session, root_signer, another_signer)
     assert tx_info is None
 
 
+async def test_eth_get_code(session, root_signer, compiled_contracts):
+    compiled_contract = compiled_contracts["EmptyContract"]
+    deployed_contract = await session.deploy(root_signer, compiled_contract.constructor(123))
+    bytecode = await session.eth_get_code(deployed_contract.address, block=Block.LATEST)
+
+    # The bytecode being deployed is not the code that will be stored on chain,
+    # but some code that, having been executed, returns the code that will be stored on chain.
+    # So all we can do is check that the code stored on chain is a part of the initialization code.
+    assert bytecode in compiled_contract.bytecode
+
+
 async def test_eth_get_filter_changes_bad_response(local_provider, session, monkeypatch):
     monkeypatch.setattr(local_provider, "eth_get_filter_changes", lambda _filter_id: {"foo": 1})
 


### PR DESCRIPTION
- support `eth_getCode`
- support `eth_getStorageAt`
- fix an issue with the default tip in transactions being too large on testnets (can't be bigger than the gas price)