### PR TITLE
More support for event logs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -41,6 +41,7 @@ Fixed
 - The transaction tip being set larger than the max gas price (which some providers don't like). (PR_64_)
 - Decoding error when fetching pending transactions. (PR_65_)
 - Decoding error when fetching pending blocks. (PR_67_)
+- Get the default nonce based on the pending block, not the latest one. (PR_68_)
 
 
 .. _PR_51: https://github.com/fjarri/pons/pull/51

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 ~~~~~~~~~~~~~~~~~~
 
 Changed
-~~~~~~~
+^^^^^^^
 
 - Added an explicit ``typing_extensions`` dependency. (PR_57_)
 - Various boolean arguments are now keyword-only to prevent usage errors. (PR_57_)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,7 @@ Added
 - ``eth_getCode`` support (as ``ClientSession.eth_get_code()``). (PR_64_)
 - ``eth_getStorageAt`` support (as ``ClientSession.eth_get_storage_at()``). (PR_64_)
 - Support for the ``logs`` field in ``TxReceipt``. (PR_68_)
+- ``ClientSession.eth_get_logs()`` and ``eth_get_filter_logs()``. (PR_68_)
 
 
 Fixed

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,6 +30,7 @@ Added
 - Expose ``Provider`` at the top level. (PR_63_)
 - ``eth_getCode`` support (as ``ClientSession.eth_get_code()``). (PR_64_)
 - ``eth_getStorageAt`` support (as ``ClientSession.eth_get_storage_at()``). (PR_64_)
+- Support for the ``logs`` field in ``TxReceipt``. (PR_68_)
 
 
 Fixed
@@ -54,6 +55,7 @@ Fixed
 .. _PR_64: https://github.com/fjarri/pons/pull/64
 .. _PR_65: https://github.com/fjarri/pons/pull/65
 .. _PR_67: https://github.com/fjarri/pons/pull/67
+.. _PR_68: https://github.com/fjarri/pons/pull/68
 
 
 0.7.0 (09-07-2023)

--- a/pons/_client.py
+++ b/pons/_client.py
@@ -785,12 +785,12 @@ class ClientSession:
         filter_id = LogFilterId.rpc_decode(result)
         return LogFilter(id_=filter_id, provider_path=provider_path)
 
-    @rpc_call("eth_getFilterChangers")
+    @rpc_call("eth_getFilterChanges")
     async def eth_get_filter_changes(
         self, filter_: Union[BlockFilter, PendingTransactionFilter, LogFilter]
     ) -> Union[Tuple[BlockHash, ...], Tuple[TxHash, ...], Tuple[LogEntry, ...]]:
         """
-        Calls the ``eth_getFilterChangers`` RPC method.
+        Calls the ``eth_getFilterChanges`` RPC method.
         Depending on what ``filter_`` was, returns a tuple of corresponding results.
         """
         # TODO: split into separate functions with specific return types?

--- a/pons/_client.py
+++ b/pons/_client.py
@@ -547,7 +547,7 @@ class ClientSession:
         # TODO (#19): implement gas strategies
         max_gas_price = await self.eth_gas_price()
         max_tip = min(Amount.gwei(1), max_gas_price)
-        nonce = await self.eth_get_transaction_count(signer.address, Block.LATEST)
+        nonce = await self.eth_get_transaction_count(signer.address, Block.PENDING)
         tx: Dict[str, Union[int, str]] = {
             "type": 2,  # EIP-2930 transaction
             "chainId": rpc_encode_quantity(chain_id),
@@ -613,7 +613,7 @@ class ClientSession:
         # TODO (#19): implement gas strategies
         max_gas_price = await self.eth_gas_price()
         max_tip = min(Amount.gwei(1), max_gas_price)
-        nonce = await self.eth_get_transaction_count(signer.address, Block.LATEST)
+        nonce = await self.eth_get_transaction_count(signer.address, Block.PENDING)
         tx: Dict[str, Union[int, str]] = {
             "type": 2,  # EIP-2930 transaction
             "chainId": rpc_encode_quantity(chain_id),
@@ -665,7 +665,7 @@ class ClientSession:
         # TODO (#19): implement gas strategies
         max_gas_price = await self.eth_gas_price()
         max_tip = min(Amount.gwei(1), max_gas_price)
-        nonce = await self.eth_get_transaction_count(signer.address, Block.LATEST)
+        nonce = await self.eth_get_transaction_count(signer.address, Block.PENDING)
         tx: Dict[str, Union[int, str]] = {
             "type": 2,  # EIP-2930 transaction
             "chainId": rpc_encode_quantity(chain_id),

--- a/pons/_client.py
+++ b/pons/_client.py
@@ -739,6 +739,49 @@ class ClientSession:
 
         return results
 
+    def _encode_filter_params(
+        self,
+        source: Optional[Union[Address, Iterable[Address]]],
+        event_filter: Optional[EventFilter],
+        from_block: Union[int, Block],
+        to_block: Union[int, Block],
+    ) -> JSON:
+        params: Dict[str, Any] = {
+            "fromBlock": rpc_encode_block(from_block),
+            "toBlock": rpc_encode_block(to_block),
+        }
+        if isinstance(source, Address):
+            params["address"] = source.rpc_encode()
+        elif source:
+            params["address"] = [address.rpc_encode() for address in source]
+        if event_filter:
+            encoded_topics: List[Optional[List[str]]] = []
+            for topic in event_filter.topics:
+                if topic is None:
+                    encoded_topics.append(None)
+                else:
+                    encoded_topics.append([elem.rpc_encode() for elem in topic])
+            params["topics"] = encoded_topics
+        return params
+
+    @rpc_call("eth_getLogs")
+    async def eth_get_logs(
+        self,
+        source: Optional[Union[Address, Iterable[Address]]] = None,
+        event_filter: Optional[EventFilter] = None,
+        from_block: Union[int, Block] = Block.LATEST,
+        to_block: Union[int, Block] = Block.LATEST,
+    ) -> Tuple[LogEntry, ...]:
+        """Calls the ``eth_getLogs`` RPC method."""
+        params = self._encode_filter_params(
+            source=source, event_filter=event_filter, from_block=from_block, to_block=to_block
+        )
+        result = await self._provider_session.rpc("eth_getLogs", params)
+        # TODO: this will go away with generalized RPC decoding.
+        if not isinstance(result, list):
+            raise InvalidResponse(f"Expected a list as a response, got {type(result).__name__}")
+        return tuple(LogEntry.rpc_decode(ResponseDict(elem)) for elem in result)
+
     @rpc_call("eth_newBlockFilter")
     async def eth_new_block_filter(self) -> BlockFilter:
         """Calls the ``eth_newBlockFilter`` RPC method."""
@@ -764,26 +807,37 @@ class ClientSession:
         to_block: Union[int, Block] = Block.LATEST,
     ) -> LogFilter:
         """Calls the ``eth_newFilter`` RPC method."""
-        params: Dict[str, Any] = {
-            "fromBlock": rpc_encode_block(from_block),
-            "toBlock": rpc_encode_block(to_block),
-        }
-        if isinstance(source, Address):
-            params["address"] = source.rpc_encode()
-        elif source:
-            params["address"] = [address.rpc_encode() for address in source]
-        if event_filter:
-            encoded_topics: List[Optional[List[str]]] = []
-            for topic in event_filter.topics:
-                if topic is None:
-                    encoded_topics.append(None)
-                else:
-                    encoded_topics.append([elem.rpc_encode() for elem in topic])
-            params["topics"] = encoded_topics
-
+        params = self._encode_filter_params(
+            source=source, event_filter=event_filter, from_block=from_block, to_block=to_block
+        )
         result, provider_path = await self._provider_session.rpc_and_pin("eth_newFilter", params)
         filter_id = LogFilterId.rpc_decode(result)
         return LogFilter(id_=filter_id, provider_path=provider_path)
+
+    def _parse_filter_result(
+        self,
+        filter_: Union[BlockFilter, PendingTransactionFilter, LogFilter],
+        result: JSON,
+    ) -> Union[Tuple[BlockHash, ...], Tuple[TxHash, ...], Tuple[LogEntry, ...]]:
+        # TODO: this will go away with generalized RPC decoding.
+        if not isinstance(result, list):
+            raise InvalidResponse(f"Expected a list as a response, got {type(result).__name__}")
+
+        if isinstance(filter_, BlockFilter):
+            return tuple(BlockHash.rpc_decode(elem) for elem in result)
+        if isinstance(filter_, PendingTransactionFilter):
+            return tuple(TxHash.rpc_decode(elem) for elem in result)
+        return tuple(LogEntry.rpc_decode(ResponseDict(elem)) for elem in result)
+
+    @rpc_call("eth_getFilterLogs")
+    async def eth_get_filter_logs(
+        self, filter_: Union[BlockFilter, PendingTransactionFilter, LogFilter]
+    ) -> Union[Tuple[BlockHash, ...], Tuple[TxHash, ...], Tuple[LogEntry, ...]]:
+        """Calls the ``eth_getFilterLogs`` RPC method."""
+        result = await self._provider_session.rpc_at_pin(
+            filter_.provider_path, "eth_getFilterLogs", filter_.id_.rpc_encode()
+        )
+        return self._parse_filter_result(filter_, result)
 
     @rpc_call("eth_getFilterChanges")
     async def eth_get_filter_changes(
@@ -794,19 +848,10 @@ class ClientSession:
         Depending on what ``filter_`` was, returns a tuple of corresponding results.
         """
         # TODO: split into separate functions with specific return types?
-        results = await self._provider_session.rpc_at_pin(
+        result = await self._provider_session.rpc_at_pin(
             filter_.provider_path, "eth_getFilterChanges", filter_.id_.rpc_encode()
         )
-
-        # TODO: this will go away with generalized RPC decoding.
-        if not isinstance(results, list):
-            raise InvalidResponse(f"Expected a list as a response, got {type(results).__name__}")
-
-        if isinstance(filter_, BlockFilter):
-            return tuple(BlockHash.rpc_decode(elem) for elem in results)
-        if isinstance(filter_, PendingTransactionFilter):
-            return tuple(TxHash.rpc_decode(elem) for elem in results)
-        return tuple(LogEntry.rpc_decode(ResponseDict(elem)) for elem in results)
+        return self._parse_filter_result(filter_, result)
 
     async def iter_blocks(self, poll_interval: int = 1) -> AsyncIterator[BlockHash]:
         """Yields hashes of new blocks being mined."""

--- a/pons/_local_provider.py
+++ b/pons/_local_provider.py
@@ -97,6 +97,8 @@ Normalizable = Union[int, bytes, Iterable["Normalizable"], Mapping[str, "Normali
 
 
 def normalize_return_value(value: Normalizable) -> JSON:
+    if isinstance(value, bool):
+        return value
     if isinstance(value, int):
         return rpc_encode_quantity(value)
     if isinstance(value, bytes):
@@ -234,6 +236,9 @@ class LocalProvider(Provider):
             result = self._ethereum_tester.get_transaction_receipt(tx_hash)
         except TransactionNotFound:
             return None
+        for entry in result["logs"]:
+            # returned by regular RPC providers, but not by EthereumTester
+            entry["removed"] = False
         return normalize_return_value(result)
 
     def eth_estimate_gas(self, tx: Mapping[str, Any], block: str) -> str:

--- a/pons/_local_provider.py
+++ b/pons/_local_provider.py
@@ -183,6 +183,8 @@ class LocalProvider(Provider):
             eth_newPendingTransactionFilter=self.eth_new_pending_transaction_filter,
             eth_newFilter=self.eth_new_filter,
             eth_getFilterChanges=self.eth_get_filter_changes,
+            eth_getLogs=self.eth_get_logs,
+            eth_getFilterLogs=self.eth_get_filter_logs,
         )
         if method not in dispatch:
             raise RPCError.method_not_found(method)
@@ -344,6 +346,29 @@ class LocalProvider(Provider):
             for result in results:
                 # returned by regular RPC providers, but not by EthereumTester
                 result["removed"] = False
+        return cast(JSON, results)
+
+    def eth_get_logs(self, params: Mapping[str, Any]) -> JSON:
+        address = params.get("address", None)
+        topics = params.get("topics", None)
+        results = self._ethereum_tester.get_logs(
+            from_block=rpc_decode_block(params["fromBlock"]),
+            to_block=rpc_decode_block(params["toBlock"]),
+            address=address,
+            topics=topics,
+        )
+        results = normalize_return_value(results)
+        for result in results:
+            # returned by regular RPC providers, but not by EthereumTester
+            result["removed"] = False
+        return cast(JSON, results)
+
+    def eth_get_filter_logs(self, filter_id: str) -> JSON:
+        results = self._ethereum_tester.get_all_filter_logs(rpc_decode_quantity(filter_id))
+        results = normalize_return_value(results)
+        for result in results:
+            # returned by regular RPC providers, but not by EthereumTester
+            result["removed"] = False
         return cast(JSON, results)
 
     @asynccontextmanager

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -620,6 +620,59 @@ async def test_pending_transaction_filter(local_provider, session, root_signer, 
     assert tx_hashes == (tx_hash,)
 
 
+async def test_eth_get_logs(
+    monkeypatch, local_provider, session, compiled_contracts, root_signer, another_signer
+):
+    basic_contract = compiled_contracts["BasicContract"]
+    await session.transfer(root_signer, another_signer.address, Amount.ether(1))
+    contract1 = await session.deploy(root_signer, basic_contract.constructor(123))
+    contract2 = await session.deploy(another_signer, basic_contract.constructor(123))
+    await session.transact(root_signer, contract1.method.deposit(b"1234"))
+    await session.transact(another_signer, contract2.method.deposit2(b"4567"))
+
+    entries = await session.eth_get_logs(source=contract2.address)
+    assert len(entries) == 1
+    assert entries[0].address == contract2.address
+    assert (
+        normalize_topics(entries[0].topics)
+        == contract2.abi.event.Deposit2(another_signer.address, b"4567").topics
+    )
+
+    # Test an invalid response
+
+    monkeypatch.setattr(local_provider, "eth_get_logs", lambda _filter_id: {"foo": 1})
+
+    with pytest.raises(
+        BadResponseFormat, match=r"eth_getLogs: Expected a list as a response, got dict"
+    ):
+        await session.eth_get_logs(source=contract2.address)
+
+
+async def test_eth_get_filter_logs(session, compiled_contracts, root_signer, another_signer):
+    basic_contract = compiled_contracts["BasicContract"]
+    await session.transfer(root_signer, another_signer.address, Amount.ether(1))
+    contract1 = await session.deploy(root_signer, basic_contract.constructor(123))
+    contract2 = await session.deploy(another_signer, basic_contract.constructor(123))
+
+    log_filter = await session.eth_new_filter()
+    await session.transact(root_signer, contract1.method.deposit(b"1234"))
+    await session.transact(another_signer, contract2.method.deposit2(b"4567"))
+
+    entries = await session.eth_get_filter_logs(log_filter)
+    assert len(entries) == 2
+    assert entries[0].address == contract1.address
+    assert entries[1].address == contract2.address
+
+    assert (
+        normalize_topics(entries[0].topics)
+        == contract1.abi.event.Deposit(root_signer.address, b"1234").topics
+    )
+    assert (
+        normalize_topics(entries[1].topics)
+        == contract2.abi.event.Deposit2(another_signer.address, b"4567").topics
+    )
+
+
 async def test_log_filter_all(session, compiled_contracts, root_signer, another_signer):
     basic_contract = compiled_contracts["BasicContract"]
     await session.transfer(root_signer, another_signer.address, Amount.ether(1))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -490,9 +490,7 @@ async def test_get_block_pending(local_provider, session, root_signer, another_s
     await session.transfer(root_signer, another_signer.address, Amount.ether(1))
 
     local_provider.disable_auto_mine_transactions()
-    await session.broadcast_transfer(
-        root_signer, another_signer.address, Amount.ether(10)
-    )
+    await session.broadcast_transfer(root_signer, another_signer.address, Amount.ether(10))
 
     block_info = await session.eth_get_block_by_number(Block.PENDING, with_transactions=True)
     assert len(block_info.transactions) == 0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -580,7 +580,7 @@ async def test_eth_get_filter_changes_bad_response(local_provider, session, monk
     block_filter = await session.eth_new_block_filter()
 
     with pytest.raises(
-        BadResponseFormat, match=r"eth_getFilterChangers: Expected a list as a response, got dict"
+        BadResponseFormat, match=r"eth_getFilterChanges: Expected a list as a response, got dict"
     ):
         await session.eth_get_filter_changes(block_filter)
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -171,7 +171,9 @@ def test_decode_tx_receipt():
                 "logIndex": "0x187",
                 "removed": False,
                 "topics": ["0x27f12abfe35860a9a927b465bb3d4a9c23c8428174b83f278fe45ed7b4da2662"],
-                "transactionHash": "0x7114b4da1a6ed391d5d781447ed443733dcf2b508c515b81c17379dea8a3c9af",
+                "transactionHash": (
+                    "0x7114b4da1a6ed391d5d781447ed443733dcf2b508c515b81c17379dea8a3c9af"
+                ),
                 "transactionIndex": "0x76",
             }
         ],

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -162,6 +162,19 @@ def test_decode_tx_receipt():
         "to": None,
         "transactionIndex": "0x18",
         "type": "0x0",
+        "logs": [
+            {
+                "address": "0x388c818ca8b9251b393131c08a736a67ccb19297",
+                "blockHash": "0x0a79eca9f5ca58a1d5d5030a0fabfdd8e815b8b77a9f223f74d59aa39596e1c7",
+                "blockNumber": "0x11e5883",
+                "data": "0x00000000000000000000000000000000000000000000000011b6b79503fb875d",
+                "logIndex": "0x187",
+                "removed": False,
+                "topics": ["0x27f12abfe35860a9a927b465bb3d4a9c23c8428174b83f278fe45ed7b4da2662"],
+                "transactionHash": "0x7114b4da1a6ed391d5d781447ed443733dcf2b508c515b81c17379dea8a3c9af",
+                "transactionIndex": "0x76",
+            }
+        ],
     }
 
     tx_receipt = TxReceipt.rpc_decode(tx_receipt_json)
@@ -178,6 +191,10 @@ def test_decode_tx_receipt():
     assert not tx_receipt.succeeded
     assert tx_receipt.contract_address is None
     assert tx_receipt.to == address
+
+    tx_receipt_json["logs"] = 1
+    with pytest.raises(RPCDecodingError, match="`logs` in a tx receipt must be an iterable, got 1"):
+        TxReceipt.rpc_decode(tx_receipt_json)
 
 
 def test_encode_decode_quantity():


### PR DESCRIPTION
- Fix some typos.
- Support for the `logs` field in `TxReceipt`.
- Get the default nonce based on the pending block, not the latest one. 
- Add `ClientSession.eth_get_logs()` and `eth_get_filter_logs()`.